### PR TITLE
[#18] 통합 테스트 초기 데이터 삭제 방식 변경

### DIFF
--- a/src/test/java/com/eventty/eventtynextgen/user/UserControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/user/UserControllerTest.java
@@ -1,4 +1,4 @@
-package com.eventty.eventtynextgen.user.controller;
+package com.eventty.eventtynextgen.user;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -53,7 +53,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -78,9 +77,6 @@ public class UserControllerTest {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
-
-    @Autowired
-    private JdbcTemplate jdbcTemplate;
 
     private static final DBConfiguration config = DBConfigurationBuilder.newBuilder()
         .setPort(13306)
@@ -114,7 +110,7 @@ public class UserControllerTest {
 
         @BeforeEach
         void cleanup() {
-            jdbcTemplate.update("DELETE FROM users WHERE email = ?", email);
+            userRepository.deleteAll();
         }
 
 
@@ -609,7 +605,7 @@ public class UserControllerTest {
 
         @BeforeEach
         void cleanup() {
-            jdbcTemplate.update("DELETE FROM users WHERE name = ? AND phone = ?", NAME, PHONE);
+            userRepository.deleteAll();
         }
 
         private final String URL = BASE_URL + "/accounts";

--- a/src/test/java/com/eventty/eventtynextgen/user/UserServiceImplTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/user/UserServiceImplTest.java
@@ -1,4 +1,4 @@
-package com.eventty.eventtynextgen.user.service;
+package com.eventty.eventtynextgen.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;


### PR DESCRIPTION
- UserControllerTest에서 JdbcTemplate 제거하고 deleteAll() 방식으로 테스트 환경 세팅

## :bell: Related issues <!-- Please write #[issue_number] -->

#18

## :pencil: Changes and Reasons <!-- Please list what you have changed and why. -->

- 기존 방식: JdbcTemplate을 사용하여 초기 테스트 데이터 삭제
- 변경된 방식: JpaRepository의 deleteAll()을 사용하여 초기 테스트 데이터 삭제

## :sparkles: PR Point <!-- what you want reviewers to focus on -->

N/A

## :gift: Notes

N/A
