### PR TITLE
[#46] CertificationTokenFilter 구현

### DIFF
--- a/src/main/java/com/eventty/eventtynextgen/base/filter/certification/CertificationAuthFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/certification/CertificationAuthFilter.java
@@ -1,0 +1,20 @@
+package com.eventty.eventtynextgen.base.filter.certification;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Order(-1)
+@Component
+public class CertificationAuthFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+    }
+}

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/certification/CertificationTokenFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/certification/CertificationTokenFilter.java
@@ -3,9 +3,8 @@ package com.eventty.eventtynextgen.base.filter.certification;
 import static com.eventty.eventtynextgen.certification.constant.CertificationConst.JWT_TOKEN_TYPE;
 import static com.eventty.eventtynextgen.shared.constant.HttpHeaderConst.*;
 
-import com.eventty.eventtynextgen.certification.core.JwtTokenProvider;
-import com.eventty.eventtynextgen.certification.core.JwtTokenProvider.AccessTokenPayload;
-import com.eventty.eventtynextgen.shared.context.AuthorizationContext;
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider;
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.AccessTokenPayload;
 import com.eventty.eventtynextgen.shared.context.AuthorizationContextHolder;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SignatureException;

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/certification/CertificationTokenFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/certification/CertificationTokenFilter.java
@@ -1,0 +1,60 @@
+package com.eventty.eventtynextgen.base.filter.certification;
+
+import static com.eventty.eventtynextgen.certification.constant.CertificationConst.JWT_TOKEN_TYPE;
+import static com.eventty.eventtynextgen.shared.constant.HttpHeaderConst.*;
+
+import com.eventty.eventtynextgen.certification.core.JwtTokenProvider;
+import com.eventty.eventtynextgen.certification.core.JwtTokenProvider.AccessTokenPayload;
+import com.eventty.eventtynextgen.shared.context.AuthorizationContext;
+import com.eventty.eventtynextgen.shared.context.AuthorizationContextHolder;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.annotation.Order;
+import org.springframework.expression.ExpressionException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Order(-2)
+@RequiredArgsConstructor
+@Component
+public class CertificationTokenFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String jwtAccessToken = this.parseJwtToken(request);
+
+        if (StringUtils.hasText(jwtAccessToken)) {
+            try {
+                this.jwtTokenProvider.verifyToken(jwtAccessToken);
+            } catch (ExpressionException | UnsupportedJwtException | IllegalStateException | SignatureException ex) {
+                // TODO - Exception 처리
+            }
+            AccessTokenPayload payload = this.jwtTokenProvider.retrievePayload(jwtAccessToken);
+
+            AuthorizationContextHolder.getContext().updateContext(payload.getUserId(), payload.getRole());
+        }
+
+        filterChain.doFilter(request, response);
+
+        AuthorizationContextHolder.clearContext();
+    }
+
+    private String parseJwtToken(HttpServletRequest request) {
+        String jwtToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (StringUtils.hasText(jwtToken) && jwtToken.startsWith(JWT_TOKEN_TYPE)) {
+            return jwtToken.substring(JWT_TOKEN_TYPE.length() + 1);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/eventty/eventtynextgen/base/provider/JwtTokenProvider.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/provider/JwtTokenProvider.java
@@ -1,6 +1,8 @@
-package com.eventty.eventtynextgen.certification.core;
+package com.eventty.eventtynextgen.base.provider;
 
 import com.eventty.eventtynextgen.certification.constant.CertificationConst;
+import com.eventty.eventtynextgen.certification.core.Authentication;
+import com.eventty.eventtynextgen.certification.core.GrantedAuthority;
 import com.eventty.eventtynextgen.certification.core.userdetails.UserDetails;
 import com.eventty.eventtynextgen.certification.refreshtoken.RefreshTokenService;
 import io.jsonwebtoken.Claims;

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
@@ -4,8 +4,8 @@ import com.eventty.eventtynextgen.certification.authentication.AuthenticationPro
 import com.eventty.eventtynextgen.certification.authentication.LoginIdPasswordAuthenticationToken;
 import com.eventty.eventtynextgen.certification.authorization.AuthorizationProvider;
 import com.eventty.eventtynextgen.certification.core.Authentication;
-import com.eventty.eventtynextgen.certification.core.JwtTokenProvider;
-import com.eventty.eventtynextgen.certification.core.JwtTokenProvider.TokenInfo;
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider;
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.TokenInfo;
 import com.eventty.eventtynextgen.certification.core.userdetails.LoginIdUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/eventty/eventtynextgen/shared/constant/HttpHeaderConst.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/constant/HttpHeaderConst.java
@@ -1,0 +1,7 @@
+package com.eventty.eventtynextgen.shared.constant;
+
+public class HttpHeaderConst {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+}

--- a/src/main/java/com/eventty/eventtynextgen/shared/context/AuthorizationContext.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/context/AuthorizationContext.java
@@ -1,0 +1,41 @@
+package com.eventty.eventtynextgen.shared.context;
+
+import java.util.Objects;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+@Getter
+public class AuthorizationContext {
+
+    private Long userId;
+    private String role;
+
+    public AuthorizationContext() {
+    }
+
+    public void updateContext(Long userId, String role) {
+        this.userId = userId;
+        this.role = role;
+    }
+
+    public boolean validate() {
+        return this.userId != null && StringUtils.hasText(role);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        AuthorizationContext that = (AuthorizationContext) object;
+        return Objects.equals(userId, that.userId) && Objects.equals(role, that.role);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, role);
+    }
+}

--- a/src/main/java/com/eventty/eventtynextgen/shared/context/AuthorizationContextHolder.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/context/AuthorizationContextHolder.java
@@ -1,0 +1,36 @@
+package com.eventty.eventtynextgen.shared.context;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.util.Assert;
+
+@UtilityClass
+public class AuthorizationContextHolder {
+
+    private static final ThreadLocal<AuthorizationContext> contextHolder = new ThreadLocal<>();
+
+    public static void clearContext() {
+        contextHolder.remove();
+    }
+
+    public static AuthorizationContext getContext() {
+        AuthorizationContext result = contextHolder.get();
+        if (result == null) {
+            AuthorizationContext context = createEmptyContext();
+            contextHolder.set(context);
+            result = context;
+        }
+
+        return result;
+    }
+
+    public static void setContext(AuthorizationContext context) {
+        Assert.notNull(context, "Only non-null authorizationContext instances are permitted");
+        contextHolder.set(context);
+    }
+
+    private static AuthorizationContext createEmptyContext() {
+        return new AuthorizationContext();
+    }
+
+    // TODO - DefferedContext 기능 추가 (비동기 처리 기능이 추가되면서 컨텍스트 전파에서 필요할 가능성이 있음)
+}

--- a/src/main/java/com/eventty/eventtynextgen/shared/exception/enums/JwtTokenErrorType.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/exception/enums/JwtTokenErrorType.java
@@ -1,0 +1,16 @@
+package com.eventty.eventtynextgen.shared.exception.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum JwtTokenErrorType implements ErrorType {
+
+    EXPIRED_ACCESS_TOKEN("EXPIRED_ACCESS_TOKEN", "Access Token의 만료기간이 지났습니다."),
+    UNSUPPORTED_TOKEN("UNSUPPORTED_TOKEN", "지원하지 않는 TOKEN 유형입니다."),
+    INVALID_TOKEN("INVALID_TOKEN", "유효하지 않는 토큰입니다.");
+
+    private final String code;
+    private final String msg;
+}

--- a/src/test/java/com/eventty/eventtynextgen/certification/core/JwtTokenProviderTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/certification/core/JwtTokenProviderTest.java
@@ -3,8 +3,9 @@ package com.eventty.eventtynextgen.certification.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider;
 import com.eventty.eventtynextgen.certification.constant.CertificationConst;
-import com.eventty.eventtynextgen.certification.core.JwtTokenProvider.TokenInfo;
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.TokenInfo;
 import com.eventty.eventtynextgen.certification.fixture.AuthenticationFixture;
 import com.eventty.eventtynextgen.certification.refreshtoken.RefreshTokenService;
 import com.eventty.eventtynextgen.certification.refreshtoken.entity.RefreshToken;


### PR DESCRIPTION
## :bell: Related issues <!-- Please write #[issue_number] -->

#46

## :pencil: Changes and Reasons <!-- Please list what you have changed and why. -->

- JwtTokenProvider 컴포넌트에 기능 추가
  - verifyToken()
  - retrievePayload
- AuthroizationContext 및 AuthorizationContextHolder 구현
- CertificationTokenFilter 구현

## :sparkles: PR Point <!-- what you want reviewers to focus on -->

1. AuthorizationContext에 저장해 둘 정보

Spring Security에서는 사용자 인증과 관련된 인자로 Authentication 객체를 사용합니다. 현재 프로젝트에서도 로그인 과정에서 이를 착안하여 Authentication 객체를 사용하였습니다. 그리고 Spring Security 에서는 SecurityContext에도 Authentication 객체를 저장합니다. 하지만 이는 필터에서 수행하는 사용자 검증 및 권한 확인 과정이라는 작업이 사용자 인증과 결합될 것으로 판단 했습니다. 또한 Authentication의 모든 필드를 사용자 검증 과정에서 필요로 하지 않습니다. 

굳이 프레임워크를 설계하는 것이 아니기 때문에 AuthroicationContext에서는 userId, role 정도만 저장해 두려고 합니다. 또한 JwtToken을 JwtTokenProvider가 파싱한 뒤 nested class인 AccessTokenPayload를 반환하도록 구현해 두었습니다.

```java
@Component
public class JwtTokenProvider {
...

    public AccessTokenPayload retrievePayload(String token) {
        Claims claims = Jwts.parserBuilder()
            .setSigningKey(getSigningKey())
            .build()
            .parseClaimsJws(token)
            .getBody();

        Long userId = Long.parseLong(claims.getSubject());
        String role = (String) claims.get("role");

        return new AccessTokenPayload(userId, role);
    }
...
    @Getter
    public static class AccessTokenPayload {

        private Long userId;
        private String role;

        public AccessTokenPayload(Long userId, String role) {
            this.userId = userId;
            this.role = role;
        }
    }
...
}
```
Authentication 객체를 사용하는 것이 좋았을지, 이와 같이 nested class를 사용하여 반환값을 정의해 두는 것이 옳은 것인지 피드백을 받고 싶습니다.

2. Filter의 예외 핸들링
Filter의 경우 Servlet 단계에서 처리되기 때문에 Advice를 기반으로 동작하는 Global Exception Handling 전략이 적용되지 않습니다. 따라서 직접 예외를 처리해 줄 필요가 있는데, 현재 두 가지 선택지에서 고민이 있습니다.

- 예외가 발생한 지점에서 예외 핸들링
- 예외를 던진 뒤 필터에서 핸들링

예시 코드와 함께 설명을 드려볼까 합니다.

```java
@Component
public class JwtTokenProvider {
....
    public void verifyToken(String token) throws ExpiredJwtException, UnsupportedJwtException, IllegalStateException, SignatureException {
        Jwts.parserBuilder()
            .setSigningKey(getSigningKey())
            .build()
            .parseClaimsJws(token);
    }
...
}

@Order(-2)
@RequiredArgsConstructor
@Component
public class CertificationTokenFilter extends OncePerRequestFilter {

private final JwtTokenProvider jwtTokenProvider;

    @Override
    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
        String jwtAccessToken = this.parseJwtToken(request);

        if (StringUtils.hasText(jwtAccessToken)) {
            try {
                this.jwtTokenProvider.verifyToken(jwtAccessToken);
            } catch (ExpressionException | UnsupportedJwtException | IllegalStateException | SignatureException ex) {
                // TODO - Exception 처리
            }
            AccessTokenPayload payload = this.jwtTokenProvider.retrievePayload(jwtAccessToken);

            AuthorizationContextHolder.getContext().updateContext(payload.getUserId(), payload.getRole());
        }

        filterChain.doFilter(request, response);

        AuthorizationContextHolder.clearContext();
    }
```

해당 방식은 필터에서 예외를 핸들링 하는 방식으로 컴포넌트에서 발생한 예외를 필터에서 일괄적으로 핸들링할 수 있다는 이점이 있습니다. 하지만 이 방식은 하위 컴포넌트에 대한 캡슐화가 깨지는 것이 아닌가에 대한 의문이 들었습니다.

이와 다른 방식으로 컴포넌트에서 직접 핸들링을 한 뒤 ErrorReponse를 만들어 줄 수 있지만 예외 응답을 만드는 지점이 여러 곳에서 생길 우려가 있으며, JwtTokenProvider와 같은 컴포넌트의 유연성을 저하시킬 것 같습니다.

어떤 방식이 좋으며, 제가 현재 드는 의문에 대한 의견을 받고 싶습니다!

3. JwtTokenProvider의 위치

현재 JwtTokenProvider는 Token을 생성하고, 검증 및 파싱하는 역할을 수행하는 객체입니다. 초기에 certification의 패키지 내부에 위치하여 로그인 과정에서 토큰을 생성해주는 작업을 수행했지만, 현재는 필터가 수행되면서 토큰을 검증하고 파싱하는 작업도 수행하고 있습니다. 

하지만 여전히 certification 패키지 내부에 위치하며, 필터는 `base.filter.certification`으로 별도 패키지에 위치합니다.

JwtTokenProvider의 위치를 옮기는 것이 좋은지, 아니면 JwtTokenProvider의 역할을 더 세분화 시켜주는 것이 좋을지에 대해서 멘토님의 의견을 받고 싶습니다!

## :gift: Notes

N/A
