### PR TITLE
[#50] 로그아웃 기능 및 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/com/eventty/eventtynextgen/base/aspect/PreAuthorizeAspect.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/aspect/PreAuthorizeAspect.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class PreAuthorizeAspect {
 
-    @Before("@within(loginRequired) || @annotation(loginRequired)")
+    @Before("@annotation(loginRequired)")
     public void checkAuthority(JoinPoint joinPoint, LoginRequired loginRequired) {
         if (loginRequired.loginRequired()) {
             if (!AuthorizationContextHolder.getContext().validate()) {

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/certification/CertificationTokenFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/certification/CertificationTokenFilter.java
@@ -21,7 +21,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
 @Order(-2)

--- a/src/main/java/com/eventty/eventtynextgen/base/provider/JwtTokenProvider.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/provider/JwtTokenProvider.java
@@ -8,8 +8,10 @@ import com.eventty.eventtynextgen.certification.core.userdetails.UserDetails;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.stream.Collectors;
@@ -76,7 +78,7 @@ public class JwtTokenProvider {
             .collect(Collectors.joining(","));
     }
 
-    public void verifyToken(String token) {
+    public void verifyToken(String token)  throws ExpiredJwtException, UnsupportedJwtException, IllegalStateException, SignatureException {
         Jwts.parserBuilder()
             .setSigningKey(getSigningKey())
             .build()

--- a/src/main/java/com/eventty/eventtynextgen/base/provider/JwtTokenProvider.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/provider/JwtTokenProvider.java
@@ -8,10 +8,8 @@ import com.eventty.eventtynextgen.certification.core.userdetails.UserDetails;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import io.jsonwebtoken.security.SignatureException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.stream.Collectors;
@@ -28,7 +26,6 @@ public class JwtTokenProvider {
     private final Long accessTokenValidityInMin;
     private final Long refreshTokenValidityInMin;
 
-
     public JwtTokenProvider(
         @Value("${key.jwt.secret-key}") String secretKey,
         @Value("${key.jwt.access-token-validity-in-min}") Long accessTokenValidityInMin,
@@ -38,7 +35,7 @@ public class JwtTokenProvider {
         this.refreshTokenValidityInMin = refreshTokenValidityInMin * 60 * 1000;
     }
 
-    public TokenInfo createToken(Authentication authentication) {
+        public TokenInfo createToken(Authentication authentication) {
         Assert.isTrue(authentication.isAuthorized(), "Only authorized users can generate a JWT token.");
 
         UserDetails userDetails = authentication.getUserDetails();
@@ -79,7 +76,7 @@ public class JwtTokenProvider {
             .collect(Collectors.joining(","));
     }
 
-    public void verifyToken(String token) throws ExpiredJwtException, UnsupportedJwtException, IllegalStateException, SignatureException {
+    public void verifyToken(String token) {
         Jwts.parserBuilder()
             .setSigningKey(getSigningKey())
             .build()

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationController.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationController.java
@@ -2,7 +2,6 @@ package com.eventty.eventtynextgen.certification;
 
 
 import com.eventty.eventtynextgen.base.annotation.LoginRequired;
-import com.eventty.eventtynextgen.certification.CertificationService.CertificationLoginResult;
 import com.eventty.eventtynextgen.certification.request.CertificationLoginRequestCommand;
 import com.eventty.eventtynextgen.certification.response.CertificationLoginResponseView;
 import com.eventty.eventtynextgen.certification.shared.annotation.CertificationApiV1;
@@ -12,8 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,21 +24,12 @@ public class CertificationController {
 
     @PostMapping("/login")
     @Operation(summary = "로그인 API")
-    public ResponseEntity<CertificationLoginResponseView> login(@RequestBody @Valid CertificationLoginRequestCommand certificationLoginRequestCommand, HttpServletResponse res) {
-        CertificationLoginResult result = this.certificationService.login(certificationLoginRequestCommand.loginId(),
-            certificationLoginRequestCommand.password());
-
-        ResponseCookie cookie = ResponseCookie.from("refreshToken", result.tokenInfo().refreshToken())
-            .httpOnly(true)
-            .secure(true)
-            .path("/")
-            .sameSite("Strict")
-            .domain("localhost")
-            .build();
-
-        res.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-
-        return ResponseEntity.ok(result.toCertificationLoginResponseView());
+    public ResponseEntity<CertificationLoginResponseView> login(@RequestBody @Valid CertificationLoginRequestCommand certificationLoginRequestCommand,
+        HttpServletResponse response) {
+        return ResponseEntity.ok(this.certificationService.login(
+            certificationLoginRequestCommand.loginId(),
+            certificationLoginRequestCommand.password(),
+            response));
     }
 
     @LoginRequired

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationController.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationController.java
@@ -3,11 +3,15 @@ package com.eventty.eventtynextgen.certification;
 
 import com.eventty.eventtynextgen.base.annotation.LoginRequired;
 import com.eventty.eventtynextgen.certification.request.CertificationLoginRequestCommand;
+import com.eventty.eventtynextgen.certification.request.CertificationReissueRequestCommand;
 import com.eventty.eventtynextgen.certification.response.CertificationLoginResponseView;
+import com.eventty.eventtynextgen.certification.response.CertificationReissueResponseView;
 import com.eventty.eventtynextgen.certification.shared.annotation.CertificationApiV1;
+import com.eventty.eventtynextgen.certification.shared.utils.CookieUtils;
 import com.eventty.eventtynextgen.shared.context.AuthorizationContextHolder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +28,8 @@ public class CertificationController {
 
     @PostMapping("/login")
     @Operation(summary = "로그인 API")
-    public ResponseEntity<CertificationLoginResponseView> login(@RequestBody @Valid CertificationLoginRequestCommand certificationLoginRequestCommand,
+    public ResponseEntity<CertificationLoginResponseView> login(
+        @RequestBody @Valid CertificationLoginRequestCommand certificationLoginRequestCommand,
         HttpServletResponse response) {
         return ResponseEntity.ok(this.certificationService.login(
             certificationLoginRequestCommand.loginId(),
@@ -35,11 +40,27 @@ public class CertificationController {
     @LoginRequired
     @PostMapping("/logout")
     @Operation(summary = "로그아웃 API")
-    public ResponseEntity<Void> logout(HttpServletResponse res) {
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
         Long userId = AuthorizationContextHolder.getContext().getUserId();
 
-        certificationService.logout(userId, res);
+        certificationService.logout(userId, response);
 
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급 요청")
+    public ResponseEntity<CertificationReissueResponseView> reissue(
+        @RequestBody @Valid CertificationReissueRequestCommand certificationReissueRequestCommand,
+        HttpServletRequest request,
+        HttpServletResponse response) {
+        String refreshToken = CookieUtils.getCookie(CookieUtils.REFRESH_TOKEN_HEADER_NAME, request);
+
+        return ResponseEntity.ok(this.certificationService.reissue(
+            certificationReissueRequestCommand.userId(),
+            certificationReissueRequestCommand.accessToken(),
+            refreshToken,
+            response
+        ));
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationController.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationController.java
@@ -1,10 +1,12 @@
 package com.eventty.eventtynextgen.certification;
 
 
+import com.eventty.eventtynextgen.base.annotation.LoginRequired;
 import com.eventty.eventtynextgen.certification.CertificationService.CertificationLoginResult;
 import com.eventty.eventtynextgen.certification.request.CertificationLoginRequestCommand;
 import com.eventty.eventtynextgen.certification.response.CertificationLoginResponseView;
 import com.eventty.eventtynextgen.certification.shared.annotation.CertificationApiV1;
+import com.eventty.eventtynextgen.shared.context.AuthorizationContextHolder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
@@ -40,5 +42,16 @@ public class CertificationController {
         res.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
         return ResponseEntity.ok(result.toCertificationLoginResponseView());
+    }
+
+    @LoginRequired
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃 API")
+    public ResponseEntity<Void> logout(HttpServletResponse res) {
+        Long userId = AuthorizationContextHolder.getContext().getUserId();
+
+        certificationService.logout(userId, res);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationService.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationService.java
@@ -2,28 +2,14 @@ package com.eventty.eventtynextgen.certification;
 
 import com.eventty.eventtynextgen.certification.response.CertificationLoginResponseView;
 import com.eventty.eventtynextgen.certification.response.CertificationLoginResponseView.AccessTokenInfo;
+import com.eventty.eventtynextgen.certification.response.CertificationReissueResponseView;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface CertificationService {
 
-    CertificationLoginResult login(String loginId, String password);
+    CertificationLoginResponseView login(String loginId, String password, HttpServletResponse response);
 
     void logout(Long userId, HttpServletResponse response);
 
-    record CertificationLoginResult(
-        Long userId,
-        String loginId,
-        TokenInfo tokenInfo
-    ) {
-        record TokenInfo(
-            String accessTokenType,
-            String accessToken,
-            String refreshToken
-        ) {}
-
-        public CertificationLoginResponseView toCertificationLoginResponseView() {
-            return new CertificationLoginResponseView(this.userId(), this.loginId(),
-                new AccessTokenInfo(this.tokenInfo().accessTokenType(), this.tokenInfo().accessToken()));
-        }
-    }
+    CertificationReissueResponseView reissue(Long userId, String accessToken, String refreshToken, HttpServletResponse response);
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationService.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationService.java
@@ -2,10 +2,13 @@ package com.eventty.eventtynextgen.certification;
 
 import com.eventty.eventtynextgen.certification.response.CertificationLoginResponseView;
 import com.eventty.eventtynextgen.certification.response.CertificationLoginResponseView.AccessTokenInfo;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface CertificationService {
 
     CertificationLoginResult login(String loginId, String password);
+
+    void logout(Long userId, HttpServletResponse response);
 
     record CertificationLoginResult(
         Long userId,

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
@@ -1,18 +1,25 @@
 package com.eventty.eventtynextgen.certification;
 
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider;
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.TokenInfo;
 import com.eventty.eventtynextgen.certification.authentication.AuthenticationProvider;
 import com.eventty.eventtynextgen.certification.authentication.LoginIdPasswordAuthenticationToken;
 import com.eventty.eventtynextgen.certification.authorization.AuthorizationProvider;
 import com.eventty.eventtynextgen.certification.core.Authentication;
-import com.eventty.eventtynextgen.base.provider.JwtTokenProvider;
-import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.TokenInfo;
 import com.eventty.eventtynextgen.certification.core.userdetails.LoginIdUserDetails;
 import com.eventty.eventtynextgen.certification.refreshtoken.RefreshTokenService;
+import com.eventty.eventtynextgen.certification.refreshtoken.entity.RefreshToken;
+import com.eventty.eventtynextgen.certification.response.CertificationLoginResponseView;
+import com.eventty.eventtynextgen.certification.response.CertificationReissueResponseView;
+import com.eventty.eventtynextgen.certification.response.CertificationReissueResponseView.AccessTokenInfo;
+import com.eventty.eventtynextgen.certification.shared.utils.CookieUtils;
+import com.eventty.eventtynextgen.shared.exception.CustomException;
+import com.eventty.eventtynextgen.shared.exception.enums.CertificationErrorType;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,35 +35,69 @@ public class CertificationServiceImpl implements CertificationService {
 
     @Override
     @Transactional
-    public CertificationLoginResult login(String loginId, String password) {
-
+    public CertificationLoginResponseView login(String loginId, String password, HttpServletResponse response) {
+        // 1. 사용자 검증
         Authentication authenticate = this.authenticationProvider.authenticate(
             LoginIdPasswordAuthenticationToken.unauthenticated(LoginIdUserDetails.fromCredentials(loginId, password)));
 
+        // 2. 사용자 역할 확인 및 권한 할당
         Authentication authorizedAuthentication = this.authorizationProvider.authorize(authenticate);
 
+        // 3. 토큰 생성
         TokenInfo tokenInfo = this.jwtTokenProvider.createToken(authorizedAuthentication);
 
-        refreshTokenService.saveOrUpdate(tokenInfo.getRefreshToken(), authorizedAuthentication.getUserDetails().getUserId());
+        // 4. Refresh Token 저장
+        this.refreshTokenService.saveOrUpdate(tokenInfo.getRefreshToken(), authorizedAuthentication.getUserDetails().getUserId());
 
-        return new CertificationLoginResult(authorizedAuthentication.getUserDetails().getUserId(), authorizedAuthentication.getUserDetails().getLoginId(),
-            new CertificationLoginResult.TokenInfo(tokenInfo.getTokenType(), tokenInfo.getAccessToken(), tokenInfo.getRefreshToken()));
+        // 5. Refresh Token 헤더에 추가
+        CookieUtils.addRefreshToken(tokenInfo.getRefreshToken(), response);
+
+        return new CertificationLoginResponseView(
+            authorizedAuthentication.getUserDetails().getUserId(),
+            authorizedAuthentication.getUserDetails().getLoginId(),
+            new CertificationLoginResponseView.AccessTokenInfo(tokenInfo.getTokenType(), tokenInfo.getAccessToken()));
     }
 
     @Override
     public void logout(Long userId, HttpServletResponse response) {
+        this.refreshTokenService.delete(userId);
 
-        refreshTokenService.delete(userId);
+        CookieUtils.removeRefreshToken(response);
+    }
 
-        ResponseCookie removedRefreshTokenCookie = ResponseCookie.from("refreshToken", "")
-            .httpOnly(true)
-            .secure(true)
-            .path("/")
-            .sameSite("Strict")
-            .domain("localhost")
-            .maxAge(0)
-            .build();
+    @Override
+    @Transactional
+    public CertificationReissueResponseView reissue(Long userId, String accessToken, String refreshToken, HttpServletResponse response) {
+        // 1. Refresh 토큰 검증
+        this.verifyAndHandleTokenException(refreshToken);
 
-        response.addHeader(HttpHeaders.SET_COOKIE, removedRefreshTokenCookie.toString());
+        // 2. Refresh 토큰 값 일치 확인
+        RefreshToken refreshTokenFromDb = this.refreshTokenService.getRefreshToken(userId);
+        if (!Objects.equals(refreshTokenFromDb.getRefreshToken(), refreshToken)) {
+            throw CustomException.badRequest(CertificationErrorType.MISMATCH_REFRESH_TOKEN);
+        }
+
+        // 3. 토큰 재발급
+        TokenInfo tokenInfo = this.jwtTokenProvider.createTokenByExpiredToken(accessToken);
+
+        // 4. 새로 발급한 Refresh Token 저장
+        this.refreshTokenService.saveOrUpdate(tokenInfo.getRefreshToken(), userId);
+
+        // 5. Refresh Token 헤더에 추가
+        CookieUtils.addRefreshToken(tokenInfo.getRefreshToken(), response);
+
+        return new CertificationReissueResponseView(
+            userId,
+            new CertificationReissueResponseView.AccessTokenInfo(tokenInfo.getTokenType(), tokenInfo.getAccessToken()));
+    }
+
+    private void verifyAndHandleTokenException(String token) {
+        try {
+            this.jwtTokenProvider.verifyToken(token);
+        } catch (ExpiredJwtException ex) {
+            throw CustomException.badRequest(CertificationErrorType.JWT_TOKEN_EXPIRED);
+        } catch (Exception ex) {
+            throw CustomException.badRequest(CertificationErrorType.FAILED_TOKEN_VERIFIED);
+        }
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
@@ -7,8 +7,12 @@ import com.eventty.eventtynextgen.certification.core.Authentication;
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider;
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.TokenInfo;
 import com.eventty.eventtynextgen.certification.core.userdetails.LoginIdUserDetails;
+import com.eventty.eventtynextgen.certification.refreshtoken.RefreshTokenService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +24,7 @@ public class CertificationServiceImpl implements CertificationService {
     private final AuthenticationProvider authenticationProvider;
     private final AuthorizationProvider authorizationProvider;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     @Override
     @Transactional
@@ -32,7 +37,26 @@ public class CertificationServiceImpl implements CertificationService {
 
         TokenInfo tokenInfo = this.jwtTokenProvider.createToken(authorizedAuthentication);
 
-        return new CertificationLoginResult(authenticate.getUserDetails().getUserId(), authenticate.getUserDetails().getLoginId(),
+        refreshTokenService.saveOrUpdate(tokenInfo.getRefreshToken(), authorizedAuthentication.getUserDetails().getUserId());
+
+        return new CertificationLoginResult(authorizedAuthentication.getUserDetails().getUserId(), authorizedAuthentication.getUserDetails().getLoginId(),
             new CertificationLoginResult.TokenInfo(tokenInfo.getTokenType(), tokenInfo.getAccessToken(), tokenInfo.getRefreshToken()));
+    }
+
+    @Override
+    public void logout(Long userId, HttpServletResponse response) {
+
+        refreshTokenService.delete(userId);
+
+        ResponseCookie removedRefreshTokenCookie = ResponseCookie.from("refreshToken", "")
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .sameSite("Strict")
+            .domain("localhost")
+            .maxAge(0)
+            .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, removedRefreshTokenCookie.toString());
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
@@ -80,7 +80,7 @@ public class CertificationServiceImpl implements CertificationService {
         }
 
         // 3. 사용자가 존재하며 활성화 상태인지 확인
-        userComponent.findByUserId(userId)
+        this.userComponent.findByUserId(userId)
             .map(user -> {
                 if (user.isDeleted()) {
                     throw CustomException.badRequest(UserErrorType.USER_ALREADY_DELETED);

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
@@ -11,7 +11,6 @@ import com.eventty.eventtynextgen.certification.refreshtoken.RefreshTokenService
 import com.eventty.eventtynextgen.certification.refreshtoken.entity.RefreshToken;
 import com.eventty.eventtynextgen.certification.response.CertificationLoginResponseView;
 import com.eventty.eventtynextgen.certification.response.CertificationReissueResponseView;
-import com.eventty.eventtynextgen.certification.response.CertificationReissueResponseView.AccessTokenInfo;
 import com.eventty.eventtynextgen.certification.shared.utils.CookieUtils;
 import com.eventty.eventtynextgen.shared.exception.CustomException;
 import com.eventty.eventtynextgen.shared.exception.enums.CertificationErrorType;
@@ -77,13 +76,13 @@ public class CertificationServiceImpl implements CertificationService {
             throw CustomException.badRequest(CertificationErrorType.MISMATCH_REFRESH_TOKEN);
         }
 
-        // 3. 토큰 재발급
+        // 4. 토큰 재발급
         TokenInfo tokenInfo = this.jwtTokenProvider.createTokenByExpiredToken(accessToken);
 
-        // 4. 새로 발급한 Refresh Token 저장
+        // 5. 새로 발급한 Refresh Token 저장
         this.refreshTokenService.saveOrUpdate(tokenInfo.getRefreshToken(), userId);
 
-        // 5. Refresh Token 헤더에 추가
+        // 6. Refresh Token 헤더에 추가
         CookieUtils.addRefreshToken(tokenInfo.getRefreshToken(), response);
 
         return new CertificationReissueResponseView(

--- a/src/main/java/com/eventty/eventtynextgen/certification/authentication/LoginIdPasswordAuthenticationToken.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/authentication/LoginIdPasswordAuthenticationToken.java
@@ -50,4 +50,9 @@ public class LoginIdPasswordAuthenticationToken implements Authentication {
     public boolean isAuthenticated() {
         return this.getUserDetails().isIdentified();
     }
+
+    @Override
+    public boolean isAuthorized() {
+        return !this.authorities.isEmpty();
+    }
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/core/Authentication.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/core/Authentication.java
@@ -10,4 +10,6 @@ public interface Authentication {
     UserDetails getUserDetails();
 
     boolean isAuthenticated();
+
+    boolean isAuthorized();
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/refreshtoken/RefreshTokenService.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/refreshtoken/RefreshTokenService.java
@@ -2,6 +2,8 @@ package com.eventty.eventtynextgen.certification.refreshtoken;
 
 
 import com.eventty.eventtynextgen.certification.refreshtoken.entity.RefreshToken;
+import com.eventty.eventtynextgen.shared.exception.CustomException;
+import com.eventty.eventtynextgen.shared.exception.enums.CertificationErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,5 +28,10 @@ public class RefreshTokenService {
     public void delete(Long userId) {
         refreshTokenRepository.findByUserId(userId)
             .ifPresent(refreshTokenRepository::delete);
+    }
+
+    public RefreshToken getRefreshToken(Long userId) {
+        return refreshTokenRepository.findByUserId(userId)
+            .orElseThrow(() -> CustomException.badRequest(CertificationErrorType.NOT_FOUND_REFRESH_TOKEN));
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/refreshtoken/RefreshTokenService.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/refreshtoken/RefreshTokenService.java
@@ -21,4 +21,10 @@ public class RefreshTokenService {
             })
             .orElseGet(() -> refreshTokenRepository.save(RefreshToken.of(refreshToken, userId)));
     }
+
+    @Transactional
+    public void delete(Long userId) {
+        refreshTokenRepository.findByUserId(userId)
+            .ifPresent(refreshTokenRepository::delete);
+    }
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/request/CertificationLoginRequestCommand.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/request/CertificationLoginRequestCommand.java
@@ -1,11 +1,14 @@
 package com.eventty.eventtynextgen.certification.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
 public record CertificationLoginRequestCommand(
     @Schema(description = "사용자 ID")
+    @NotBlank(message = "사용자 ID는 필수값입니다.")
     String loginId,
     @Schema(description = "사용자 패스워드")
+    @NotBlank(message = "사용자 PW는 필수값입니다.")
     String password
 ){
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/request/CertificationReissueRequestCommand.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/request/CertificationReissueRequestCommand.java
@@ -1,0 +1,16 @@
+package com.eventty.eventtynextgen.certification.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CertificationReissueRequestCommand(
+
+    @Schema(description = "사용자 PK")
+    @NotNull(message = "사용자 ID는 필수값입니다.")
+    Long userId,
+    @Schema(description = "엑세스 토큰")
+    @NotBlank(message = "엑세스 토큰은 필수값입니다.")
+    String accessToken
+) {
+}

--- a/src/main/java/com/eventty/eventtynextgen/certification/response/CertificationReissueResponseView.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/response/CertificationReissueResponseView.java
@@ -1,0 +1,17 @@
+package com.eventty.eventtynextgen.certification.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CertificationReissueResponseView(
+    @Schema(description = "사용자 PK")
+    Long userId,
+    @Schema(description = "토큰 정보")
+    AccessTokenInfo accessTokenInfo
+) {
+    public record AccessTokenInfo(
+        @Schema(description = "토큰 타입")
+        String tokenType,
+        @Schema(description = "엑세스 토큰")
+        String accessToken
+    ){}
+}

--- a/src/main/java/com/eventty/eventtynextgen/certification/shared/utils/CookieUtils.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/shared/utils/CookieUtils.java
@@ -1,0 +1,35 @@
+package com.eventty.eventtynextgen.certification.shared.utils;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.experimental.UtilityClass;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+@UtilityClass
+public class CookieUtils {
+
+    public static void addRefreshToken(String refreshToken, HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .sameSite("Strict")
+            .domain("localhost")
+            .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    public static void removeRefreshToken(HttpServletResponse response) {
+        ResponseCookie removedRefreshTokenCookie = ResponseCookie.from("refreshToken", "")
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .sameSite("Strict")
+            .domain("localhost")
+            .maxAge(0)
+            .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, removedRefreshTokenCookie.toString());
+    }
+}

--- a/src/main/java/com/eventty/eventtynextgen/certification/shared/utils/CookieUtils.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/shared/utils/CookieUtils.java
@@ -1,5 +1,6 @@
 package com.eventty.eventtynextgen.certification.shared.utils;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.experimental.UtilityClass;
 import org.springframework.http.HttpHeaders;
@@ -8,8 +9,14 @@ import org.springframework.http.ResponseCookie;
 @UtilityClass
 public class CookieUtils {
 
+    public static String REFRESH_TOKEN_HEADER_NAME = "refreshToken";
+
+    public static String getCookie(String name, HttpServletRequest request) {
+        return request.getHeader(name);
+    }
+
     public static void addRefreshToken(String refreshToken, HttpServletResponse response) {
-        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_HEADER_NAME, refreshToken)
             .httpOnly(true)
             .secure(true)
             .path("/")
@@ -21,7 +28,7 @@ public class CookieUtils {
     }
 
     public static void removeRefreshToken(HttpServletResponse response) {
-        ResponseCookie removedRefreshTokenCookie = ResponseCookie.from("refreshToken", "")
+        ResponseCookie removedRefreshTokenCookie = ResponseCookie.from(REFRESH_TOKEN_HEADER_NAME, "")
             .httpOnly(true)
             .secure(true)
             .path("/")

--- a/src/main/java/com/eventty/eventtynextgen/shared/context/AuthorizationContext.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/context/AuthorizationContext.java
@@ -21,7 +21,7 @@ public class AuthorizationContext {
     }
 
     public boolean validate() {
-        return this.userId != null && StringUtils.hasText(role);
+        return Objects.nonNull(this.userId) && StringUtils.hasText(role);
     }
 
     @Override

--- a/src/main/java/com/eventty/eventtynextgen/shared/exception/enums/CertificationErrorType.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/exception/enums/CertificationErrorType.java
@@ -15,7 +15,7 @@ public enum CertificationErrorType implements ErrorType {
     // Authentication
     AUTH_PASSWORD_MISMATCH("AUTH_PASSWORD_MISMATCH", "패스워드가 일치하지 않습니다."),
     AUTH_USER_NOT_ACTIVE("AUTH_USER_NOT_ACTIVE", "해당 유저는 활성화 상태가 아닙니다."),
-    JWT_TOKEN_EXPIRED("JWT_TOKEN_EXPIRED", "JWT 토큰 인증 기간이 지났습니다. 재발급을 시도하세요"),
+    JWT_TOKEN_EXPIRED("JWT_TOKEN_EXPIRED", "토큰 인증 기간이 지났습니다. 재발급을 시도하세요"),
     FAILED_TOKEN_VERIFIED("FAILED_TOKEN_VERIFIED", "토큰 검증에 실패했습니다."),
 
     // Authorization
@@ -24,9 +24,11 @@ public enum CertificationErrorType implements ErrorType {
 
     NOT_FOUND_API_NAME_TYPE("NOT_FOUND_API_NAME_TYPE", "URI에 일치하는 value를 찾을 수 없습니다."),
     NOT_FOUND_AUTHORIZATION_API_PROPERTY("NOT_FOUND_AUTHORIZATION_API_PROPERTY", "일치하는 Properties를 찾을 수 없습니다."),
+    NOT_FOUND_REFRESH_TOKEN("NOT_FOUND_REFRESH_TOKEN", "해당 사용자로 저장되어 있는 Refresh Token을 찾을 수 없습니다."),
+
+    MISMATCH_REFRESH_TOKEN("MISMATCH_REFRESH_TOKEN", "저장되어 있는 Refresh Token과 값이 일치하지 않습니다."),
 
     UNKNOWN_EXCEPTION("UNKNOWN_EXCEPTION", "예상치 못한 예외가 발생했습니다. 문제 해결 조치를 위해 author과 컨택하세요.");
-
 
     private final String code;
     private final String msg;

--- a/src/main/java/com/eventty/eventtynextgen/user/UserController.java
+++ b/src/main/java/com/eventty/eventtynextgen/user/UserController.java
@@ -1,7 +1,5 @@
 package com.eventty.eventtynextgen.user;
 
-import com.eventty.eventtynextgen.base.annotation.PreAuthorize;
-import com.eventty.eventtynextgen.certification.authorization.enums.AuthorizationType;
 import com.eventty.eventtynextgen.user.request.UserChangePasswordRequestCommand;
 import com.eventty.eventtynextgen.user.request.UserSignUpRequestCommand;
 import com.eventty.eventtynextgen.user.request.UserUpdateRequestCommand;

--- a/src/test/java/com/eventty/eventtynextgen/base/provider/JwtTokenProviderTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/provider/JwtTokenProviderTest.java
@@ -1,19 +1,16 @@
-package com.eventty.eventtynextgen.certification.core;
+package com.eventty.eventtynextgen.base.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider;
-import com.eventty.eventtynextgen.certification.constant.CertificationConst;
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.TokenInfo;
+import com.eventty.eventtynextgen.certification.constant.CertificationConst;
+import com.eventty.eventtynextgen.certification.core.Authentication;
 import com.eventty.eventtynextgen.certification.fixture.AuthenticationFixture;
-import com.eventty.eventtynextgen.certification.refreshtoken.RefreshTokenService;
-import com.eventty.eventtynextgen.certification.refreshtoken.entity.RefreshToken;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/eventty/eventtynextgen/certification/CertificationControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/certification/CertificationControllerTest.java
@@ -3,6 +3,7 @@ package com.eventty.eventtynextgen.certification;
 import static com.eventty.eventtynextgen.shared.constant.HttpHeaderConst.AUTHORIZATION_HEADER;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -13,13 +14,15 @@ import ch.vorburger.mariadb4j.DBConfiguration;
 import ch.vorburger.mariadb4j.DBConfigurationBuilder;
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider;
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.TokenInfo;
+import com.eventty.eventtynextgen.certification.provider.TestJwtTokenProvider;
 import com.eventty.eventtynextgen.certification.constant.CertificationConst;
 import com.eventty.eventtynextgen.certification.core.Authentication;
 import com.eventty.eventtynextgen.certification.fixture.AuthenticationFixture;
 import com.eventty.eventtynextgen.certification.refreshtoken.RefreshTokenRepository;
 import com.eventty.eventtynextgen.certification.refreshtoken.entity.RefreshToken;
 import com.eventty.eventtynextgen.certification.request.CertificationLoginRequestCommand;
-import com.eventty.eventtynextgen.shared.constant.HttpHeaderConst;
+import com.eventty.eventtynextgen.certification.request.CertificationReissueRequestCommand;
+import com.eventty.eventtynextgen.certification.shared.utils.CookieUtils;
 import com.eventty.eventtynextgen.shared.exception.CustomException;
 import com.eventty.eventtynextgen.shared.exception.ErrorResponse;
 import com.eventty.eventtynextgen.shared.exception.enums.CertificationErrorType;
@@ -37,6 +40,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -45,6 +49,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -74,6 +79,9 @@ class CertificationControllerTest {
 
     @Autowired
     private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private Environment environment;
 
     private static final DBConfiguration config = DBConfigurationBuilder.newBuilder()
         .setPort(13306)
@@ -261,6 +269,181 @@ class CertificationControllerTest {
 
             // then
             resultActions.andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 재발급 테스트")
+    class Reissue {
+
+        private static final String URL = BASE_URL + "/reissue";
+        private TestJwtTokenProvider testJwtTokenProvider;
+
+        @BeforeEach
+        void setup() {
+            String secretKey = environment.getProperty("key.jwt.secret-key");
+            testJwtTokenProvider = TestJwtTokenProvider.of(secretKey);
+        }
+
+        @AfterEach
+        void tearDown() {
+            refreshTokenRepository.deleteAll();
+        }
+
+        @Test
+        @DisplayName("저장되어 있는 유효한 Refresh Token을 통해 재발급 요청시 재발급에 성공한다")
+        void 저장되어_있는_유효한_리프래시_토큰을_통해_재발급_요청시_재발급에_성공한다() throws Exception {
+            // given
+            Long userId = 1L;
+            String accessToken = testJwtTokenProvider.createExpiredAccessToken(userId);
+            String refreshToken = testJwtTokenProvider.createValidRefreshToken();
+            refreshTokenRepository.save(RefreshToken.of(refreshToken, userId));
+
+            CertificationReissueRequestCommand certificationReissueRequestCommand = new CertificationReissueRequestCommand(userId, accessToken);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post(URL)
+                .header(CookieUtils.REFRESH_TOKEN_HEADER_NAME, refreshToken)
+                .content(objectMapper.writeValueAsString(certificationReissueRequestCommand))
+                .contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            resultActions.andExpect(status().isOk())
+                .andExpect(cookie().exists("refreshToken"))
+                .andExpect(jsonPath("$.userId").value(userId))
+                .andExpect(jsonPath("$.accessTokenInfo.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.accessTokenInfo.accessToken").isNotEmpty());
+        }
+
+        @Test
+        @DisplayName("만료된 Refresh Token을 통해 재발급 요청시 재발급에 실패한다")
+        void 만료된_리프래시_토큰을_통해_재발급_요청시_재발급에_실패한다() throws Exception {
+            // given
+            Long userId = 1L;
+            String accessToken = testJwtTokenProvider.createExpiredAccessToken(1L);
+            String refreshToken = testJwtTokenProvider.createExpiredRefreshToken();
+            refreshTokenRepository.save(RefreshToken.of(refreshToken, userId));
+
+            CertificationReissueRequestCommand certificationReissueRequestCommand = new CertificationReissueRequestCommand(userId, accessToken);
+
+            ResponseEntity<ErrorResponse> responseEntity = ErrorResponseEntityFactory.toResponseEntity(
+                CustomException.badRequest(CertificationErrorType.JWT_TOKEN_EXPIRED));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post(URL)
+                .header(CookieUtils.REFRESH_TOKEN_HEADER_NAME, refreshToken)
+                .content(objectMapper.writeValueAsString(certificationReissueRequestCommand))
+                .contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            resultActions.andExpect(status().isBadRequest())
+                .andExpect(
+                    content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
+        }
+
+        @Test
+        @DisplayName("토큰 서명 겁증에 실패할 경우 재발급에 실패한다")
+        void 토큰_서명_검증에_실패할_경우_재발급에_실패한다() throws Exception{
+            // given
+            Long userId = 1L;
+            String accessToken = testJwtTokenProvider.createExpiredAccessToken(1L);
+            String refreshToken = testJwtTokenProvider.createRefreshTokenWithInvalidSignature();
+            refreshTokenRepository.save(RefreshToken.of(refreshToken, userId));
+
+            CertificationReissueRequestCommand certificationReissueRequestCommand = new CertificationReissueRequestCommand(userId, accessToken);
+
+            ResponseEntity<ErrorResponse> responseEntity = ErrorResponseEntityFactory.toResponseEntity(
+                CustomException.badRequest(CertificationErrorType.FAILED_TOKEN_VERIFIED));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post(URL)
+                .header(CookieUtils.REFRESH_TOKEN_HEADER_NAME, refreshToken)
+                .content(objectMapper.writeValueAsString(certificationReissueRequestCommand))
+                .contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            resultActions.andExpect(status().isBadRequest())
+                .andExpect(
+                    content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
+        }
+
+        @Test
+        @DisplayName("올바르지 않은 형식으로 구성된 Refresh Token을 통하여 재발급 요청시 재발급에 실패한다")
+        void 올바르지_않은_형식으로_구성된_리프래시_토큰을_통하여_재발급_요청시_재발급에_실패한다() throws Exception{
+            // given
+            Long userId = 1L;
+            String accessToken = testJwtTokenProvider.createExpiredAccessToken(1L);
+            String refreshToken = testJwtTokenProvider.createIllegalRefreshToken();
+            refreshTokenRepository.save(RefreshToken.of(refreshToken, userId));
+
+            CertificationReissueRequestCommand certificationReissueRequestCommand = new CertificationReissueRequestCommand(userId, accessToken);
+
+            ResponseEntity<ErrorResponse> responseEntity = ErrorResponseEntityFactory.toResponseEntity(
+                CustomException.badRequest(CertificationErrorType.FAILED_TOKEN_VERIFIED));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post(URL)
+                .header(CookieUtils.REFRESH_TOKEN_HEADER_NAME, refreshToken)
+                .content(objectMapper.writeValueAsString(certificationReissueRequestCommand))
+                .contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            resultActions.andExpect(status().isBadRequest())
+                .andExpect(
+                    content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
+        }
+
+        @Test
+        @DisplayName("저장되어 있지 않은 Refresh Token을 통해 재발급 요청시 재발급에 실패한다")
+        void 저장되어_있지_않은_리프래시_토큰을_통해_재발급_요청시_재발급에_실패한다() throws Exception {
+            // given
+            Long userId = 1L;
+            String accessToken = testJwtTokenProvider.createExpiredAccessToken(1L);
+            String refreshToken = testJwtTokenProvider.createValidRefreshToken();
+
+            CertificationReissueRequestCommand certificationReissueRequestCommand = new CertificationReissueRequestCommand(userId, accessToken);
+
+            ResponseEntity<ErrorResponse> responseEntity = ErrorResponseEntityFactory.toResponseEntity(
+                CustomException.badRequest(CertificationErrorType.NOT_FOUND_REFRESH_TOKEN));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post(URL)
+                .header(CookieUtils.REFRESH_TOKEN_HEADER_NAME, refreshToken)
+                .content(objectMapper.writeValueAsString(certificationReissueRequestCommand))
+                .contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            resultActions.andExpect(status().isBadRequest())
+                .andExpect(
+                    content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
+        }
+
+        @Test
+        @DisplayName("저장되어 있는 Refresh Token과 값이 일치하지 않은 경우 재발급에 실패한다")
+        void 저장되어_있는_리프래시_토큰과_값이_일치하지_않을_경우_재발급에_실패한다() throws Exception {
+            // given
+            Long userId = 1L;
+            String accessToken = testJwtTokenProvider.createExpiredAccessToken(1L);
+            String refreshToken = testJwtTokenProvider.createValidRefreshToken();
+            refreshTokenRepository.save(RefreshToken.of(refreshToken, userId));
+
+            String differentRefreshToken = testJwtTokenProvider.createDifferentRefreshToken();
+
+            CertificationReissueRequestCommand certificationReissueRequestCommand = new CertificationReissueRequestCommand(userId, accessToken);
+
+            ResponseEntity<ErrorResponse> responseEntity = ErrorResponseEntityFactory.toResponseEntity(
+                CustomException.badRequest(CertificationErrorType.MISMATCH_REFRESH_TOKEN));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post(URL)
+                .header(CookieUtils.REFRESH_TOKEN_HEADER_NAME, differentRefreshToken)
+                .content(objectMapper.writeValueAsString(certificationReissueRequestCommand))
+                .contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            resultActions.andExpect(status().isBadRequest())
+                .andExpect(
+                    content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
         }
     }
 }

--- a/src/test/java/com/eventty/eventtynextgen/certification/CertificationServiceImplTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/certification/CertificationServiceImplTest.java
@@ -1,0 +1,193 @@
+package com.eventty.eventtynextgen.certification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider;
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.TokenInfo;
+import com.eventty.eventtynextgen.certification.authentication.AuthenticationProvider;
+import com.eventty.eventtynextgen.certification.authorization.AuthorizationProvider;
+import com.eventty.eventtynextgen.certification.constant.CertificationConst;
+import com.eventty.eventtynextgen.certification.refreshtoken.RefreshTokenService;
+import com.eventty.eventtynextgen.certification.refreshtoken.entity.RefreshToken;
+import com.eventty.eventtynextgen.certification.response.CertificationReissueResponseView;
+import com.eventty.eventtynextgen.shared.exception.CustomException;
+import com.eventty.eventtynextgen.shared.exception.enums.CertificationErrorType;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Certification Service 단위 테스트")
+class CertificationServiceImplTest {
+
+    @Mock
+    private AuthenticationProvider authenticationProvider;
+
+    @Mock
+    private AuthorizationProvider authorizationProvider;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Nested
+    @DisplayName("비즈니스 로직 - 토큰 재발급")
+    class Reissue {
+
+        @Test
+        @DisplayName("저장되어 있는 유효한 RefreshToken을 이용한 토큰 재발급 요청은 `성공`한다")
+        void 저장되어_있는_유효한_리프래시_토큰을_이용한_재발급_요청은_성공한다() {
+            // given
+            Long userId = 1L;
+            String expiredAccessToken = "expired_access_token";
+            String refreshToken = "valid_refresh_token";
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            RefreshToken refreshTokenFromDb = mock(RefreshToken.class);
+            TokenInfo tokenInfo = createMockTokenInfo();
+
+            doNothing().when(jwtTokenProvider).verifyToken(refreshToken);
+            when(refreshTokenService.getRefreshToken(userId)).thenReturn(refreshTokenFromDb);
+            when(refreshTokenFromDb.getRefreshToken()).thenReturn(refreshToken);
+            when(jwtTokenProvider.createTokenByExpiredToken(expiredAccessToken)).thenReturn(tokenInfo);
+            when(refreshTokenService.saveOrUpdate(tokenInfo.getRefreshToken(), userId)).thenReturn(mock(RefreshToken.class));
+
+            CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
+                refreshTokenService);
+
+            // when
+            CertificationReissueResponseView result = certificationService.reissue(userId, expiredAccessToken, refreshToken, response);
+
+            // then
+            assertThat(result.userId()).isEqualTo(userId);
+            assertThat(result.accessTokenInfo().accessToken()).isEqualTo(tokenInfo.getAccessToken());
+            assertThat(result.accessTokenInfo().tokenType()).isEqualTo(CertificationConst.JWT_TOKEN_TYPE);
+        }
+
+        @Test
+        @DisplayName("만료기간이 지난 RefreshToken을 이용한 토큰 재발급 요청은 `실패`한다")
+        void 만료기간이_지난_리프래시_토큰을_이용한_토큰_재발급_요청은_실패한다() {
+            // given
+            Long userId = 1L;
+            String expiredAccessToken = "expired_access_token";
+            String expiredRefreshToken = "expired_refresh_token";
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            doThrow(ExpiredJwtException.class).when(jwtTokenProvider).verifyToken(expiredRefreshToken);
+
+            CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
+                refreshTokenService);
+
+            // when & then
+            assertThatThrownBy(() ->
+                certificationService.reissue(userId, expiredAccessToken, expiredRefreshToken, response))
+                .extracting(ex -> ((CustomException) ex).getErrorType()).isEqualTo(CertificationErrorType.JWT_TOKEN_EXPIRED);
+        }
+
+        @Test
+        @DisplayName("형식이 잘못된 RefreshToken을 이용한 토큰 재발급 요청은 `실패`한다")
+        void 형식이_잘못된_리프래시_토큰을_이용한_토큰_재발급_요청은_실패한다() {
+            // given
+            Long userId = 1L;
+            String expiredAccessToken = "expired_access_token";
+            String expiredRefreshToken = "expired_refresh_token";
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            doThrow(IllegalStateException.class).when(jwtTokenProvider).verifyToken(expiredRefreshToken);
+
+            CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
+                refreshTokenService);
+
+            // when & then
+            assertThatThrownBy(() ->
+                certificationService.reissue(userId, expiredAccessToken, expiredRefreshToken, response))
+                .extracting(ex -> ((CustomException) ex).getErrorType()).isEqualTo(CertificationErrorType.FAILED_TOKEN_VERIFIED);
+        }
+
+        @Test
+        @DisplayName("서명이 잘못된 RefreshToken을 이용한 토큰 재발급 요청은 `실패`한다")
+        void 서멍이_잘못된_리프래시_토큰을_이용한_토큰_재발급_요청은_실패한다() {
+            // given
+            Long userId = 1L;
+            String expiredAccessToken = "expired_access_token";
+            String expiredRefreshToken = "expired_refresh_token";
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            doThrow(SignatureException.class).when(jwtTokenProvider).verifyToken(expiredRefreshToken);
+
+            CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
+                refreshTokenService);
+
+            // when & then
+            assertThatThrownBy(() ->
+                certificationService.reissue(userId, expiredAccessToken, expiredRefreshToken, response))
+                .extracting(ex -> ((CustomException) ex).getErrorType()).isEqualTo(CertificationErrorType.FAILED_TOKEN_VERIFIED);
+        }
+
+        @Test
+        @DisplayName("저장되어 있지 않은 RefreshToken을 이용한 토큰 재발급 요청은 `실패`한다")
+        void 저장되어_있지_않은_리프래시_토큰을_이용한_토큰_재발급_요청은_실패한다() {
+            // given
+            Long userId = 1L;
+            String expiredAccessToken = "expired_access_token";
+            String refreshToken = "refresh_token";
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            doNothing().when(jwtTokenProvider).verifyToken(refreshToken);
+            doThrow(CustomException.class).when(refreshTokenService).getRefreshToken(userId);
+
+            CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
+                refreshTokenService);
+
+            // when & then
+            assertThatThrownBy(() ->
+                certificationService.reissue(userId, expiredAccessToken, refreshToken, response))
+                .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("사용자 id를 통해 조회한 RefreshToken과 값이 일치하지 않을 경우 토큰 재발급 요청은 `실패`한다")
+        void 사용자_id를_통해_조회한_리프래시_토큰과_값이_일치하지_않을_경우_토큰_재발급_요청은_실패한다() {
+            // given
+            Long userId = 1L;
+            String expiredAccessToken = "expired_access_token";
+            String refreshToken = "refresh_token";
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            RefreshToken refreshTokenFromDb = mock(RefreshToken.class);
+
+            doNothing().when(jwtTokenProvider).verifyToken(refreshToken);
+            when(refreshTokenService.getRefreshToken(userId)).thenReturn(refreshTokenFromDb);
+            when(refreshTokenFromDb.getRefreshToken()).thenReturn("mismatch_refresh_token");
+
+            CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
+                refreshTokenService);
+
+            // when & then
+            assertThatThrownBy(() ->
+                certificationService.reissue(userId, expiredAccessToken, refreshToken, response))
+                .extracting(ex -> ((CustomException) ex).getErrorType()).isEqualTo(CertificationErrorType.MISMATCH_REFRESH_TOKEN);
+        }
+
+        private TokenInfo createMockTokenInfo() {
+            TokenInfo mock = mock(TokenInfo.class);
+            when(mock.getTokenType()).thenReturn(CertificationConst.JWT_TOKEN_TYPE);
+            when(mock.getAccessToken()).thenReturn("new_access_token");
+            when(mock.getRefreshToken()).thenReturn("new_refresh_token");
+            return mock;
+        }
+    }
+}

--- a/src/test/java/com/eventty/eventtynextgen/certification/core/JwtTokenProviderTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/certification/core/JwtTokenProviderTest.java
@@ -20,9 +20,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayName("JwtTokenProvider 단위 테스트")
 class JwtTokenProviderTest {
 
-    @Mock
-    private RefreshTokenService refreshTokenService;
-
     @Nested
     @DisplayName("토큰 생성")
     class CreateToken {
@@ -37,9 +34,7 @@ class JwtTokenProviderTest {
             // given
             Authentication authentication = AuthenticationFixture.createAuthenticatedLoginIdPasswordAuthentication();
 
-            when(refreshTokenService.saveOrUpdate(any(String.class), any(Long.class))).thenReturn(mock(RefreshToken.class));
-
-            JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(SECRET_KEY, TOKEN_VALIDITY_IN_MIN, TOKEN_VALIDITY_IN_MIN, refreshTokenService);
+            JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(SECRET_KEY, TOKEN_VALIDITY_IN_MIN, TOKEN_VALIDITY_IN_MIN);
 
             // when
             TokenInfo token = jwtTokenProvider.createToken(authentication);
@@ -56,7 +51,7 @@ class JwtTokenProviderTest {
             // given
             Authentication authentication = AuthenticationFixture.createUnauthenticatedLoginIdPasswordAuthentication();
 
-            JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(SECRET_KEY, TOKEN_VALIDITY_IN_MIN, TOKEN_VALIDITY_IN_MIN, refreshTokenService);
+            JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(SECRET_KEY, TOKEN_VALIDITY_IN_MIN, TOKEN_VALIDITY_IN_MIN);
 
             // when & then
             try {

--- a/src/test/java/com/eventty/eventtynextgen/certification/core/JwtTokenProviderTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/certification/core/JwtTokenProviderTest.java
@@ -32,7 +32,7 @@ class JwtTokenProviderTest {
         @DisplayName("인증된 사용자는 토큰 생성에 성공한다.")
         void 인증된_사용자는_토큰_생성에_성공한다() {
             // given
-            Authentication authentication = AuthenticationFixture.createAuthenticatedLoginIdPasswordAuthentication();
+            Authentication authentication = AuthenticationFixture.createAuthorizedLoginIdPasswordAuthentication(1L, "email@gmail.com", "plain_password");
 
             JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(SECRET_KEY, TOKEN_VALIDITY_IN_MIN, TOKEN_VALIDITY_IN_MIN);
 
@@ -58,7 +58,7 @@ class JwtTokenProviderTest {
                 jwtTokenProvider.createToken(authentication);
             } catch (Exception ex) {
                 assertThat(ex.getClass()).isEqualTo(IllegalArgumentException.class);
-                assertThat(ex.getMessage()).isEqualTo("Only authenticated users can generate a JWT token.");
+                assertThat(ex.getMessage()).isEqualTo("Only authorized users can generate a JWT token.");
             }
         }
     }

--- a/src/test/java/com/eventty/eventtynextgen/certification/fixture/AuthenticationFixture.java
+++ b/src/test/java/com/eventty/eventtynextgen/certification/fixture/AuthenticationFixture.java
@@ -2,6 +2,13 @@ package com.eventty.eventtynextgen.certification.fixture;
 
 import com.eventty.eventtynextgen.certification.authentication.LoginIdPasswordAuthenticationToken;
 import com.eventty.eventtynextgen.certification.core.Authentication;
+import com.eventty.eventtynextgen.certification.core.GrantedAuthority;
+import com.eventty.eventtynextgen.certification.core.autority.SimpleGrantedAuthority;
+import com.eventty.eventtynextgen.certification.core.userdetails.UserDetails;
+import com.eventty.eventtynextgen.user.entity.enums.UserRoleType;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 public class AuthenticationFixture {
 
@@ -13,7 +20,10 @@ public class AuthenticationFixture {
         return LoginIdPasswordAuthenticationToken.unauthenticated(UserDetailsFixture.createLoginIdUserDetailsFromPrincipal());
     }
 
-    public static Authentication createAuthorizedLoginIdPasswordAuthentication() {
-        return LoginIdPasswordAuthenticationToken.unauthenticated(UserDetailsFixture.createLoginIdUserDetailsFromPrincipal());
+    public static Authentication createAuthorizedLoginIdPasswordAuthentication(Long userId, String loginId, String plainPassword) {
+        UserDetails userDetails = UserDetailsFixture.createLoginIdUserDetailsFromPrincipal(userId, loginId, plainPassword);
+        LoginIdPasswordAuthenticationToken authenticated = LoginIdPasswordAuthenticationToken.authenticated(userDetails);
+        Collection<? extends GrantedAuthority> grantedAuthorities = List.of(new SimpleGrantedAuthority(UserRoleType.USER.name()));
+        return LoginIdPasswordAuthenticationToken.authorized(authenticated, grantedAuthorities);
     }
 }

--- a/src/test/java/com/eventty/eventtynextgen/certification/fixture/UserDetailsFixture.java
+++ b/src/test/java/com/eventty/eventtynextgen/certification/fixture/UserDetailsFixture.java
@@ -14,4 +14,8 @@ public class UserDetailsFixture {
     public static UserDetails createLoginIdUserDetailsFromPrincipal() {
         return LoginIdUserDetails.fromPrincipal(1L, "example@gmail.com", PasswordEncoder.encode("password"), UserRoleType.USER, false);
     }
+
+    public static UserDetails createLoginIdUserDetailsFromPrincipal(Long userId, String loginId, String plainPassword) {
+        return LoginIdUserDetails.fromPrincipal(userId, loginId, PasswordEncoder.encode(plainPassword), UserRoleType.USER, false);
+    }
 }

--- a/src/test/java/com/eventty/eventtynextgen/certification/provider/TestJwtTokenProvider.java
+++ b/src/test/java/com/eventty/eventtynextgen/certification/provider/TestJwtTokenProvider.java
@@ -1,0 +1,98 @@
+package com.eventty.eventtynextgen.certification.provider;
+
+import com.eventty.eventtynextgen.certification.authorization.enums.AuthorizationType;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Date;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
+public class TestJwtTokenProvider {
+
+    private static final KeyGenerator keyGen;
+
+    private static final Long VALID_TOKEN_VALIDITY_IN_MIN = (long) (60 * 60 * 1000);
+    private static final Long INVALID_TOKEN_VALIDITY_IN_MIN = (long) (-60 * 60 * 1000);
+
+    private final String secretKey;
+
+    static {
+        try {
+            keyGen = KeyGenerator.getInstance("HmacSHA256");
+        } catch (NoSuchAlgorithmException e) {
+            System.err.println("KeyGenerator를 초기화하는 과정에서 예외가 발생했습니다. msg: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+        keyGen.init(256); // 키 길이를 256비트로 설정
+    }
+
+    private TestJwtTokenProvider (String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public static TestJwtTokenProvider of(String secretKey) {
+        return new TestJwtTokenProvider(secretKey);
+    }
+
+    public String createExpiredAccessToken(Long userId) {
+        long now = new Date(System.currentTimeMillis()).getTime();
+        return Jwts.builder()
+            .setSubject(String.valueOf(userId))
+            .claim("role", AuthorizationType.ROLE_USER)
+            .claim("appName", "eventty")
+            .setExpiration(new Date(now + INVALID_TOKEN_VALIDITY_IN_MIN))
+            .signWith(this.getSigningKey())
+            .compact();
+    }
+
+    public String createValidRefreshToken() {
+        long now = new Date(System.currentTimeMillis()).getTime();
+        return Jwts.builder()
+            .setExpiration(new Date(now + VALID_TOKEN_VALIDITY_IN_MIN))
+            .signWith(this.getSigningKey())
+            .compact();
+    }
+
+    public String createDifferentRefreshToken() {
+        long now = new Date(System.currentTimeMillis()).getTime();
+        return Jwts.builder()
+            .setExpiration(new Date(now + VALID_TOKEN_VALIDITY_IN_MIN * 60))
+            .signWith(this.getSigningKey())
+            .compact();
+    }
+
+    public String createExpiredRefreshToken() {
+        long now = new Date(System.currentTimeMillis()).getTime();
+        return Jwts.builder()
+            .setExpiration(new Date(now + INVALID_TOKEN_VALIDITY_IN_MIN))
+            .signWith(this.getSigningKey())
+            .compact();
+    }
+
+    public String createRefreshTokenWithInvalidSignature() {
+        long now = new Date(System.currentTimeMillis()).getTime();
+        return Jwts.builder()
+            .setExpiration(new Date(now + INVALID_TOKEN_VALIDITY_IN_MIN))
+            .signWith(this.getInvalidSigningKey())
+            .compact();
+    }
+
+    public String createIllegalRefreshToken() {
+        return "invalid.token.format";
+    }
+
+    private SecretKey getSigningKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(this.secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    private SecretKey getInvalidSigningKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(Base64.getEncoder().encodeToString(keyGen.generateKey().getEncoded()));
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public record TokenInfo(String tokenType, String accessToken, String refreshToken) { }
+}


### PR DESCRIPTION
## :bell: Related issues <!-- Please write #[issue_number] -->

#50

## :pencil: Changes and Reasons <!-- Please list what you have changed and why. -->

- 로그아웃 기능 구현
- 토큰 재발급 기능 구현
  - 토큰 재발급 로직의 통합 테스트를 위해 `TestJwtTokenProvider` 객체 구현
- RefreshToken을 Http Response 헤더에 담는 로직을 서비스 레이어에서 수행하도록 변경 
  - Cookie에 담아주는 작업을 위한 CookieUtils 유틸리티 클래스 구현
- JwtTokenProvider 리팩토링
  - Public method와 private method를 세분화여 분리

## :sparkles: PR Point <!-- what you want reviewers to focus on -->

1. **JwtTokenProvider의 verifyToken()의 Exception Throw**

JwtTokenProvider는 verifyToken을 수행하는 과정에서 Exception이 발생시 직접 예외를 핸들링하여 던지는 것이 아니라, 호출하는 객체에게 발생할 수 있는 예외를 알려주고 이것을 핸들링 하라는 의도로 아래와 같이 구현을 해두었습니다.

```java
public void verifyToken(String token)  throws ExpiredJwtException, UnsupportedJwtException, IllegalStateException, SignatureException {
    Jwts.parserBuilder()
        .setSigningKey(getSigningKey())
        .build()
        .parseClaimsJws(token);
}
```

이와 같이 구현한 의도는 Filter에서 토큰을 검증하는 과정에서 발생할 수 있는 예외를 직접 다루기 위해서 이와 같이 해두었습니다. 이것을 `CertificationServiceImpl.reissue()`에서도 사용하도록 구현을 해두어서 아래와 같은 방식으로 처리가 됩니다.

```java
@Override
@Transactional
public CertificationReissueResponseView reissue(Long userId, String accessToken, String refreshToken, HttpServletResponse response) {
    // 1. Refresh 토큰 검증
    this.verifyAndHandleTokenException(refreshToken);
...
}
private void verifyAndHandleTokenException(String token) {
    try {
        this.jwtTokenProvider.verifyToken(token);
    } catch (ExpiredJwtException ex) {
        throw CustomException.badRequest(CertificationErrorType.JWT_TOKEN_EXPIRED);
    } catch (Exception ex) {
        throw CustomException.badRequest(CertificationErrorType.FAILED_TOKEN_VERIFIED);
    }
}
```

이와 같이 처리하는 것이 올바른지 아니면 `JwtTokenProvider`에서 `verifyTokenHandlingException`과 같은 메서드를 추가로 구현하는 것이 좋을지 피드백을 받고 싶습니다.

2. **CertificationServiceImpl에서 UserComponent를 사용하는 방식**

현재 `CertificationServiceImpl.reissue()`의 로직 중 하나인 사용자가 활성화 상태인지 확인하는 것을 수행하기 위해서 아래와 같이 로직이 추가되어 있습니다.

```java
@Override
@Transactional
public CertificationReissueResponseView reissue(Long userId, String accessToken, String refreshToken, HttpServletResponse response) {
...
// 3. 사용자가 존재하며 활성화 상태인지 확인
        this.userComponent.findByUserId(userId)
            .map(user -> {
                if (user.isDeleted()) {
                    throw CustomException.badRequest(UserErrorType.USER_ALREADY_DELETED);
                }
                return user;
            })
            .orElseThrow(() -> CustomException.badRequest(UserErrorType.NOT_FOUND_USER));
...
}
```

`CertificationService`는 현재 Certification 도메인의 최상위 레이어에 위치하고 있는 Service 객체이기 때문에 userComponent를 의존하여 이와 같이 진행하는 것이 올바른지 의문이 듭니다.

`userComponent`에서 사용자가 활성화 상태인지 호출하는 메서드를 구현해도 괜찮다면 차라리 해당 메서드를 호출하여 진행하는 것이 올바른 형태가 아닐가 싶습니다. 

`UserComponent`에서 사용자의 특정 상태를 확인하는 메서드를 구현해도 괜찮을지 피드백을 주시면 감사하겠습니다.

3. **Controller에서 RefreshToken을 가져오는 행위**

현재 RefreshToken은 HttpOnly 방식으로 쿠키에 저장이 되며, 재발급 요청 API가 호출될 경우 헤더에 저장되어 있는 RefreshToken을 꺼내와야 합니다. 이를 위해서 Service 레이어가 아닌 Controller 에서 아래와 같은 방식으로 구현을 해두었습니다.

```java
@PostMapping("/reissue")
public ResponseEntity<CertificationReissueResponseView> reissue(
@RequestBody @Valid CertificationReissueRequestCommand certificationReissueRequestCommand,
    HttpServletRequest request,
    HttpServletResponse response) {
    String refreshToken = CookieUtils.getCookie(CookieUtils.REFRESH_TOKEN_HEADER_NAME, request);  // 해당 부분

    return ResponseEntity.ok(this.certificationService.reissue(
        certificationReissueRequestCommand.userId(),
        certificationReissueRequestCommand.accessToken(),
        refreshToken,
        response
    ));
}
```

이와 같은 방식으로 진행을 하였는데, Service 레이어에서 수행하는 것이 좋을지, 아니면 Controller에서 수행하는 것이 좋을지 피드백을 받고 싶습니다.

4. **TestJwtTokenProvider**

토큰에 대한 재발급 요청 로직의 통합 테스트를 진행하기 위해서는 만료된 토큰이나 서명이 잘못된 토큰 등 다양한 토큰에 대한 생성이 필요하며, 이 과정에서 properties로 숨겨져 있는 `SecretKey`를 이용해야 합니다.

또한 만료된 토큰이나 잘못된 토큰에 대한 생성은 개발 환경에서 제공되면 안되는 API이므로 별도의 Test 환경을 위한 `TestJwtTokenProvider`를 생성하기로 결정 했습니다.

아래와 같은 2가지 방식을 고려했습니다.

- JwtTokenProvider의 Interface를 만든 뒤, 테스트 객체를 만들어서 상속하여 구현
- 상속 X, 컴포넌트 X인 테스트 객체를 만들고 오로지 토큰을 생성하는 역할을 수행

첫 번째 방식으로 진행할 경우, JwtTokenProvider에 대한 변경이 테스트 객체에 크게 영향을 주는 것은 물론이고 통합 테스트 환경은 가능한 실제 환경과 가장 유사하도록 진행이 되어야 하는데 별도의 테스트 객체가 실제 컴포넌트를 대체하게 될 경우 이것이 크게 깨진다고 생각이 들었습니다.

따라서 아래 방식으로 진행을 하였습니다.

아래 방식으로 진행하게 될 경우 `SecretKey`를 각각 테스트마다 직접 주입받아야 하고, 이를 위해서 `@BeforeEach setup()`안에서 properties의 key값을 통해 직접 받아오고 [TestJwtTokenProvider](https://github.com/jeongbeomSeo/eventty-nextgen/blob/d699ccd9f17a511f90dfa68b807fb0f8391c1686/src/test/java/com/eventty/eventtynextgen/certification/provider/TestJwtTokenProvider.java)를 생성하도록 진행을 했습니다. 

이것이 올바른 방향으로 진행한 것이지 피드백을 부탁드리겠습니다.

5. **Controller에서 userId를 받아오는 방식**

현재 사용자의 로그인이 필요한 API 중에서 사용자의 ID가 비즈니스 로직에 직접 필요한 경우 `RequestCommand`에 담겨서 오도록 진행하고 있습니다. 이를테면 사용자 수정이나 사용자 삭제, 사용자 상태 변경 등이 이에 해당하는 API라고 볼 수 있습니다. 

이전 프로젝트에서는 `Spring Security`의 방식인 `public ResponseEntity<> method(@AuthenticationPrincipal CustomUserDetails user) {}` 형태로 진행을 했었습니다.

그 이전에는 ThreadLocal에 저장되어 있는 userId를 Controller에서 직접 꺼내와서 Service 객체를 호출할 때 인자로 건네 주었습니다.

```java
@GetMapping( "/url")
@Permission(Roles = {UserRole.HOST})
public ResponseEntity<> method() {
    Long hostId = getUserIdBySecurityContextHolder();
    return ResponseEntity.ok(eventService.method(hostId));
}
```

Spring Security의 방식처럼 커스텀 어노테이션을 만들어서 AOP 이용하거나 아니면 Resolver를 이용한 방법도 가능할 것이라고 판단이 됩니다. 어떤 방식으로 진행하는 것이 좋을지에 대해서 의견을 받고 싶습니다. 

## :gift: Notes

N/A
