### PR TITLE
[#62] Certification Token 생성 API 구현 및 Login 로직 수정

### DIFF
--- a/src/main/java/com/eventty/eventtynextgen/base/constant/BaseConst.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/constant/BaseConst.java
@@ -8,4 +8,8 @@ public class BaseConst {
 
     public static final String EVENTTY_NAME = "eventty";
 
+    public static final String APP_NAME_KEY = "AppName";
+    public static final String ADMIN_EMAIL_KEY = "AdminEmail";
+    public static final String API_ALLOW_KEY = "API_Allow";
+
 }

--- a/src/main/java/com/eventty/eventtynextgen/base/constant/BaseConst.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/constant/BaseConst.java
@@ -6,8 +6,6 @@ public class BaseConst {
 
     public static final ObjectMapper objectMapper = new ObjectMapper();
 
-    public static final String EVENTTY_NAME = "eventty";
-
     public static final String APP_NAME_KEY = "AppName";
     public static final String ADMIN_EMAIL_KEY = "AdminEmail";
     public static final String API_ALLOW_KEY = "API_Allow";

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/certification/AuthenticationFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/certification/AuthenticationFilter.java
@@ -1,0 +1,5 @@
+package com.eventty.eventtynextgen.base.filter.certification;
+
+public class AuthenticationFilter {
+
+}

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/certification/AuthorizationFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/certification/AuthorizationFilter.java
@@ -1,0 +1,5 @@
+package com.eventty.eventtynextgen.base.filter.certification;
+
+public class AuthorizationFilter {
+
+}

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/certification/CertificationAuthFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/certification/CertificationAuthFilter.java
@@ -21,8 +21,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
-@Order(-1)
-@Component
+//@Order(-1)
+//@Component
 @RequiredArgsConstructor
 public class CertificationAuthFilter extends OncePerRequestFilter {
 
@@ -31,41 +31,41 @@ public class CertificationAuthFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        // 1. URI와 METHOD 가져오기
-        String requestUrl = request.getRequestURI();
-
-        try {
-            // 2. ApiNameType으로 부터 패턴 매칭 후 일치하는 상수 가져오기
-            ApiName authorizationApiName = ApiNamePatternMatcher.getApiName(requestUrl)
-                .orElseThrow(() -> CustomException.badRequest(CertificationErrorType.NOT_FOUND_API_NAME_TYPE, String.format("The URI (%s) is not a registered API path. Please contact the administrator.", requestUrl)));
-
-            // 3. properties를 이용하여 권한 가져오기
-            String appName = AuthorizationContextHolder.getContext().getAppName();
-            String permission = authorizationApiProperties.getPermission(appName, authorizationApiName);
-            if (permission == null) {
-                throw CustomException.of(HttpStatus.INTERNAL_SERVER_ERROR, CertificationErrorType.NOT_FOUND_AUTHORIZATION_API_PROPERTY, String.format("authorizationApiName.name: %s", authorizationApiName.name()));
-            }
-
-            // 4. 권한을 통해서 API 호출 권한 확인
-            checkApiPermission(permission);
-
-            // 5. 전부 통과시 패스
-            doFilter(request, response, filterChain);
-        } catch (CustomException ex) {
-            log.error("http-status={} code={} msg={} detail={}",
-                ex.getHttpStatus().value(),
-                ex.getErrorType().getCode(),
-                ex.getErrorType().getMsg(),
-                ex.getDetail());
-            ResponseUtils.writeErrorResponseToResponse(response, ex);
-        } catch (Throwable ex) {
-            log.error("http-status={} code={} msg={} detail={}",
-                HttpStatus.FORBIDDEN.value(),
-                CertificationErrorType.UNKNOWN_EXCEPTION.getCode(),
-                CertificationErrorType.UNKNOWN_EXCEPTION.getMsg(),
-                ex.getMessage());
-            ResponseUtils.writeErrorResponseToResponse(response, HttpStatus.FORBIDDEN, ex, CertificationErrorType.UNKNOWN_EXCEPTION);
-        }
+//        // 1. URI와 METHOD 가져오기
+//        String requestUrl = request.getRequestURI();
+//
+//        try {
+//            // 2. ApiNameType으로 부터 패턴 매칭 후 일치하는 상수 가져오기
+//            ApiName authorizationApiName = ApiNamePatternMatcher.getApiName(requestUrl)
+//                .orElseThrow(() -> CustomException.badRequest(CertificationErrorType.NOT_FOUND_API_NAME_TYPE, String.format("The URI (%s) is not a registered API path. Please contact the administrator.", requestUrl)));
+//
+//            // 3. properties를 이용하여 권한 가져오기
+//            String appName = AuthorizationContextHolder.getContext().getAppName();
+//            String permission = authorizationApiProperties.getPermission(appName, authorizationApiName);
+//            if (permission == null) {
+//                throw CustomException.of(HttpStatus.INTERNAL_SERVER_ERROR, CertificationErrorType.NOT_FOUND_AUTHORIZATION_API_PROPERTY, String.format("authorizationApiName.name: %s", authorizationApiName.name()));
+//            }
+//
+//            // 4. 권한을 통해서 API 호출 권한 확인
+//            checkApiPermission(permission);
+//
+//            // 5. 전부 통과시 패스
+//            doFilter(request, response, filterChain);
+//        } catch (CustomException ex) {
+//            log.error("http-status={} code={} msg={} detail={}",
+//                ex.getHttpStatus().value(),
+//                ex.getErrorType().getCode(),
+//                ex.getErrorType().getMsg(),
+//                ex.getDetail());
+//            ResponseUtils.writeErrorResponseToResponse(response, ex);
+//        } catch (Throwable ex) {
+//            log.error("http-status={} code={} msg={} detail={}",
+//                HttpStatus.FORBIDDEN.value(),
+//                CertificationErrorType.UNKNOWN_EXCEPTION.getCode(),
+//                CertificationErrorType.UNKNOWN_EXCEPTION.getMsg(),
+//                ex.getMessage());
+//            ResponseUtils.writeErrorResponseToResponse(response, HttpStatus.FORBIDDEN, ex, CertificationErrorType.UNKNOWN_EXCEPTION);
+//        }
     }
 
     private void checkApiPermission(String permission) {

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/certification/LoginFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/certification/LoginFilter.java
@@ -1,0 +1,5 @@
+package com.eventty.eventtynextgen.base.filter.certification;
+
+public class LoginFilter {
+
+}

--- a/src/main/java/com/eventty/eventtynextgen/base/properties/AuthorizationApiProperties.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/properties/AuthorizationApiProperties.java
@@ -1,11 +1,12 @@
 package com.eventty.eventtynextgen.base.properties;
 
-import com.eventty.eventtynextgen.base.enums.ApiName;
+import com.eventty.eventtynextgen.shared.exception.CustomException;
+import com.eventty.eventtynextgen.shared.exception.enums.CertificationErrorType;
 import java.util.Map;
-import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 @Getter
@@ -14,24 +15,47 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "authorization")
 public class AuthorizationApiProperties {
 
-    private Map<String, Map<String, String>> permissions;
+    private Map<String, AppPermission> infoMap;
 
-    public String getPermission(String appName, ApiName apiName) {
-        String apiKey = apiName.name().toLowerCase().replace("_", "-");
-
-        Map<String, String> allPermissions = permissions.get("all");
-        if (allPermissions.containsKey(apiKey)) {
-            return allPermissions.get(apiKey);
+    public Permission getApiPermission(String appName, String apiName) {
+        if (!this.containsAppName(appName)) {
+            throw CustomException.badRequest(CertificationErrorType.NOT_ALLOW_APP_NAME);
         }
 
-        if (Objects.nonNull(appName) && permissions.containsKey(appName)) {
-            Map<String, String> appPermissions = permissions.get(appName);
-            if (appPermissions.containsKey(apiKey)) {
-                return appPermissions.get(apiKey);
-            }
+        AppPermission appPermission = infoMap.get(appName);
+        if (!appPermission.containsApiPermission(apiName)) {
+            throw CustomException.of(HttpStatus.valueOf(500), CertificationErrorType.NOT_REGISTERED_API_NAME);
         }
 
-        return null;
+        return appPermission.getAppPermissions().get(apiName);
+    }
+
+    public Map<String, Permission> getPermissions(String appName) {
+        if (!this.containsAppName(appName)) {
+            throw CustomException.badRequest(CertificationErrorType.NOT_ALLOW_APP_NAME);
+        }
+
+        return infoMap.get(appName).getAppPermissions();
+    }
+    public boolean containsAppName(String appName) {
+        return infoMap.containsKey(appName);
+    }
+
+    @Getter
+    @Setter
+    private static class AppPermission {
+        private Map<String, Permission> appPermissions;
+
+        public boolean containsApiPermission(String apiName) {
+            return this.appPermissions.containsKey(apiName);
+        }
+    }
+
+    @Getter
+    public enum Permission {
+        FREE,
+        LOGIN,
+        OPTIONAL
     }
 }
 

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationController.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationController.java
@@ -2,10 +2,12 @@ package com.eventty.eventtynextgen.certification;
 
 
 import com.eventty.eventtynextgen.base.annotation.LoginRequired;
+import com.eventty.eventtynextgen.certification.request.CertificationIssueCertificationTokenRequestCommand;
 import com.eventty.eventtynextgen.certification.request.CertificationLoginRequestCommand;
 import com.eventty.eventtynextgen.certification.request.CertificationReissueRequestCommand;
+import com.eventty.eventtynextgen.certification.response.CertificationIssueCertificationTokenResponseView;
 import com.eventty.eventtynextgen.certification.response.CertificationLoginResponseView;
-import com.eventty.eventtynextgen.certification.response.CertificationReissueResponseView;
+import com.eventty.eventtynextgen.certification.response.CertificationReissueAccessTokenResponseView;
 import com.eventty.eventtynextgen.certification.annotation.CertificationApiV1;
 import com.eventty.eventtynextgen.certification.shared.utils.CookieUtils;
 import com.eventty.eventtynextgen.shared.context.AuthorizationContextHolder;
@@ -48,19 +50,25 @@ public class CertificationController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/reissue")
+    @PostMapping("/reissue/access-token")
     @Operation(summary = "토큰 재발급 요청")
-    public ResponseEntity<CertificationReissueResponseView> reissue(
+    public ResponseEntity<CertificationReissueAccessTokenResponseView> reissueAccessToken(
         @RequestBody @Valid CertificationReissueRequestCommand certificationReissueRequestCommand,
         HttpServletRequest request,
         HttpServletResponse response) {
         String refreshToken = CookieUtils.getCookie(CookieUtils.REFRESH_TOKEN_HEADER_NAME, request);
 
-        return ResponseEntity.ok(this.certificationService.reissue(
+        return ResponseEntity.ok(this.certificationService.reissueAccessToken(
             certificationReissueRequestCommand.userId(),
             certificationReissueRequestCommand.accessToken(),
             refreshToken,
             response
         ));
+    }
+
+    @PostMapping("/issue/certification-token")
+    public ResponseEntity<CertificationIssueCertificationTokenResponseView> issueCertificationToken(@RequestBody
+        CertificationIssueCertificationTokenRequestCommand certificationIssueCertificationTokenRequestCommand) {
+        return ResponseEntity.ok(this.certificationService.issueCertificationToken(certificationIssueCertificationTokenRequestCommand.accessToken()));
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationService.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationService.java
@@ -1,8 +1,8 @@
 package com.eventty.eventtynextgen.certification;
 
+import com.eventty.eventtynextgen.certification.response.CertificationIssueCertificationTokenResponseView;
 import com.eventty.eventtynextgen.certification.response.CertificationLoginResponseView;
-import com.eventty.eventtynextgen.certification.response.CertificationLoginResponseView.AccessTokenInfo;
-import com.eventty.eventtynextgen.certification.response.CertificationReissueResponseView;
+import com.eventty.eventtynextgen.certification.response.CertificationReissueAccessTokenResponseView;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface CertificationService {
@@ -11,5 +11,7 @@ public interface CertificationService {
 
     void logout(Long userId, HttpServletResponse response);
 
-    CertificationReissueResponseView reissue(Long userId, String accessToken, String refreshToken, HttpServletResponse response);
+    CertificationReissueAccessTokenResponseView reissueAccessToken(Long userId, String accessToken, String refreshToken, HttpServletResponse response);
+
+    CertificationIssueCertificationTokenResponseView issueCertificationToken(String appName);
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
@@ -8,6 +8,7 @@ import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.CertificationTo
 import com.eventty.eventtynextgen.certification.authentication.AuthenticationProvider;
 import com.eventty.eventtynextgen.certification.authentication.LoginIdPasswordAuthenticationToken;
 import com.eventty.eventtynextgen.certification.authorization.AuthorizationProvider;
+import com.eventty.eventtynextgen.certification.authuser.AuthUserService;
 import com.eventty.eventtynextgen.certification.core.Authentication;
 import com.eventty.eventtynextgen.certification.core.userdetails.LoginIdUserDetails;
 import com.eventty.eventtynextgen.certification.refreshtoken.RefreshTokenService;
@@ -40,6 +41,7 @@ public class CertificationServiceImpl implements CertificationService {
     private final RefreshTokenService refreshTokenService;
     private final UserComponent userComponent;
     private final AuthorizationApiProperties authorizationApiProperties;
+    private final AuthUserService authUserService;
 
     @Override
     @Transactional
@@ -55,6 +57,7 @@ public class CertificationServiceImpl implements CertificationService {
         AccessTokenInfo tokenInfo = this.jwtTokenProvider.createAccessToken(authorizedAuthentication);
 
         // 4. 토큰(Session ID)와 로그인한 사용자 정보 영속화
+        authUserService.saveAuthUser(tokenInfo.getAccessToken(), tokenInfo.getAccessTokenExpiredAt(), authorizedAuthentication);
 
         // 5. Refresh Token 영속화
         this.refreshTokenService.saveOrUpdate(tokenInfo.getRefreshToken(), authorizedAuthentication.getUserDetails().getUserId());
@@ -98,7 +101,7 @@ public class CertificationServiceImpl implements CertificationService {
             .orElseThrow(() -> CustomException.badRequest(UserErrorType.NOT_FOUND_USER));
 
         // 4. 토큰 재발급
-        AccessTokenInfo tokenInfo = this.jwtTokenProvider.createAccessTokenByExpiredToken(accessToken);
+        AccessTokenInfo tokenInfo = this.jwtTokenProvider.createAccessTokenByExpiredToken();
 
         // 5. 새로 발급한 Refresh Token 저장
         this.refreshTokenService.saveOrUpdate(tokenInfo.getRefreshToken(), userId);

--- a/src/main/java/com/eventty/eventtynextgen/certification/authuser/AuthUserService.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/authuser/AuthUserService.java
@@ -1,6 +1,10 @@
 package com.eventty.eventtynextgen.certification.authuser;
 
+import com.eventty.eventtynextgen.certification.authuser.entity.AuthUser;
+import com.eventty.eventtynextgen.certification.core.Authentication;
+import java.util.Date;
+
 public interface AuthUserService {
 
-
+    AuthUser saveAuthUser(String sessionId, Date sessionIdExpiredAt, Authentication authentication);
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/authuser/AuthUserService.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/authuser/AuthUserService.java
@@ -1,0 +1,6 @@
+package com.eventty.eventtynextgen.certification.authuser;
+
+public interface AuthUserService {
+
+
+}

--- a/src/main/java/com/eventty/eventtynextgen/certification/authuser/AuthUserServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/authuser/AuthUserServiceImpl.java
@@ -1,0 +1,5 @@
+package com.eventty.eventtynextgen.certification.authuser;
+
+public class AuthUserServiceImpl {
+
+}

--- a/src/main/java/com/eventty/eventtynextgen/certification/authuser/AuthUserServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/authuser/AuthUserServiceImpl.java
@@ -1,5 +1,35 @@
 package com.eventty.eventtynextgen.certification.authuser;
 
-public class AuthUserServiceImpl {
+import com.eventty.eventtynextgen.certification.authuser.entity.AuthUser;
+import com.eventty.eventtynextgen.certification.authuser.repository.AuthUserRepository;
+import com.eventty.eventtynextgen.certification.core.Authentication;
+import com.eventty.eventtynextgen.shared.exception.CustomException;
+import com.eventty.eventtynextgen.shared.exception.enums.CommonErrorType;
+import com.eventty.eventtynextgen.shared.utils.DateUtils;
+import java.time.LocalDateTime;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
 
+@Component
+@RequiredArgsConstructor
+public class AuthUserServiceImpl implements AuthUserService {
+
+    private final AuthUserRepository authUserRepository;
+    // TODO: 리팩토링 하는 과정에서 AuthenticationProvider, AuthorizationProvider를 해당 객체로 옮겨서 처리
+    // TODO: Provider의 역할과 메서드의 책임을 고려하여 사용자 인증 과정에서 사용하는 사용자 호출 로직이나 사용자에게 권한 인가 과정에서 발생하는 검증 처리는 상위 메서드에서 처리
+
+    @Override
+    public AuthUser saveAuthUser(String sessionId, Date sessionIdExpiredAt, Authentication authentication) {
+        if (!authentication.isAuthorized()) {
+            throw CustomException.of(HttpStatus.INTERNAL_SERVER_ERROR, CommonErrorType.INVALID_INPUT_DATA,
+                "Auth User를 생성하기 위해서는 인증·인가 작업이 완료된 Authentication 객체가 필요합니다.");
+        }
+
+        AuthUser authUser = AuthUser.of(authentication.getUserDetails().getUserId(), authentication.getUserDetails().getUserRole().name(), sessionId,
+            DateUtils.convertFormatToLocalDateTime(sessionIdExpiredAt));
+
+        return this.authUserRepository.save(authUser);
+    }
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/authuser/entity/AuthUser.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/authuser/entity/AuthUser.java
@@ -6,7 +6,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.Date;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,12 +23,31 @@ public class AuthUser {
     @Id
     private Long userId;
 
-    @Column(name = "session_id", nullable = false, unique = true)
-    private String sessionId;
-
     @Column(name = "user_role", nullable = false)
     private String userRole;
 
+    @Column(name = "session_id", nullable = false, unique = true)
+    private String sessionId;
+
     @Column(name = "expired_at", nullable = false)
     private LocalDateTime expiredAt;
+
+    @Builder
+    private AuthUser(Long userId, String userRole, String sessionId, LocalDateTime expiredAt) {
+        this.userId = userId;
+        this.userRole = userRole;
+        this.sessionId = sessionId;
+        this.expiredAt = expiredAt;
+    }
+
+
+
+    public static AuthUser of(Long userId, String userRole, String sessionId, LocalDateTime expiredAt) {
+        return AuthUser.builder()
+            .userId(userId)
+            .userRole(userRole)
+            .sessionId(sessionId)
+            .expiredAt(expiredAt)
+            .build();
+    }
 }

--- a/src/main/java/com/eventty/eventtynextgen/certification/authuser/entity/AuthUser.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/authuser/entity/AuthUser.java
@@ -1,0 +1,32 @@
+package com.eventty.eventtynextgen.certification.authuser.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "auth_user", indexes =
+    @Index(name = "session_id_idx", columnList = "session_id")
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuthUser {
+
+    @Id
+    private Long userId;
+
+    @Column(name = "session_id", nullable = false, unique = true)
+    private String sessionId;
+
+    @Column(name = "user_role", nullable = false)
+    private String userRole;
+
+    @Column(name = "expired_at", nullable = false)
+    private LocalDateTime expiredAt;
+}

--- a/src/main/java/com/eventty/eventtynextgen/certification/authuser/repository/AuthUserRepository.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/authuser/repository/AuthUserRepository.java
@@ -1,0 +1,8 @@
+package com.eventty.eventtynextgen.certification.authuser.repository;
+
+import com.eventty.eventtynextgen.certification.authuser.entity.AuthUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthUserRepository extends JpaRepository<AuthUser, Long> {
+
+}

--- a/src/main/java/com/eventty/eventtynextgen/certification/request/CertificationIssueCertificationTokenRequestCommand.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/request/CertificationIssueCertificationTokenRequestCommand.java
@@ -1,0 +1,7 @@
+package com.eventty.eventtynextgen.certification.request;
+
+public record CertificationIssueCertificationTokenRequestCommand(
+    String accessToken
+) {
+
+}

--- a/src/main/java/com/eventty/eventtynextgen/certification/response/CertificationIssueCertificationTokenResponseView.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/response/CertificationIssueCertificationTokenResponseView.java
@@ -1,0 +1,8 @@
+package com.eventty.eventtynextgen.certification.response;
+
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.CertificationTokenInfo;
+
+public record CertificationIssueCertificationTokenResponseView(
+    CertificationTokenInfo certificationToken
+) {
+}

--- a/src/main/java/com/eventty/eventtynextgen/certification/response/CertificationReissueAccessTokenResponseView.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/response/CertificationReissueAccessTokenResponseView.java
@@ -2,7 +2,7 @@ package com.eventty.eventtynextgen.certification.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record CertificationReissueResponseView(
+public record CertificationReissueAccessTokenResponseView(
     @Schema(description = "사용자 PK")
     Long userId,
     @Schema(description = "토큰 정보")

--- a/src/main/java/com/eventty/eventtynextgen/shared/exception/enums/CertificationErrorType.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/exception/enums/CertificationErrorType.java
@@ -23,8 +23,11 @@ public enum CertificationErrorType implements ErrorType {
     AUTH_USER_NOT_AUTHORIZED("AUTH_USER_NOT_AUTHORIZED", "사용자의 API 호출 권한이 없습니다."),
 
     NOT_FOUND_API_NAME_TYPE("NOT_FOUND_API_NAME_TYPE", "URI에 일치하는 value를 찾을 수 없습니다."),
+    NOT_ALLOW_APP_NAME("NOT_ALLOW_APP_NAME", "API 호출이 허용되지 않은 APP입니다."),
+    NOT_FOUND_APP_NAME("NOT_FOUND_APP_NAME", "찾을 수 없는 APP NAME입니다."),
     NOT_FOUND_AUTHORIZATION_API_PROPERTY("NOT_FOUND_AUTHORIZATION_API_PROPERTY", "일치하는 Properties를 찾을 수 없습니다."),
     NOT_FOUND_REFRESH_TOKEN("NOT_FOUND_REFRESH_TOKEN", "해당 사용자로 저장되어 있는 Refresh Token을 찾을 수 없습니다."),
+    NOT_REGISTERED_API_NAME("NOT_REGISTERED_API_NAME", "해당 API NAME이 올바르게 등록되어 있지 않습니다. 서버 개발자에에 문의해 주세요."),
 
     MISMATCH_REFRESH_TOKEN("MISMATCH_REFRESH_TOKEN", "저장되어 있는 Refresh Token과 값이 일치하지 않습니다."),
 

--- a/src/main/java/com/eventty/eventtynextgen/shared/utils/DateUtils.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/utils/DateUtils.java
@@ -1,0 +1,16 @@
+package com.eventty.eventtynextgen.shared.utils;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class DateUtils {
+
+    public static LocalDateTime convertFormatToLocalDateTime(Date date) {
+        return date.toInstant()
+            .atZone(ZoneId.systemDefault())
+            .toLocalDateTime();
+    }
+}

--- a/src/main/resources/application-authorization.yml
+++ b/src/main/resources/application-authorization.yml
@@ -1,10 +1,10 @@
 authorization:
-  permissions:
-    all:
-      swagger: FREE
-      health: FREE
-      certification: FREE
-      user: FREE
-    eventty:
-      certification: FREE
-      user: FREE
+  infoMap:
+    swagger:
+      app-permissions:
+        all: FREE
+    client-app1:
+      app-permissions:
+        user: OPTIONAL
+        certification: OPTIONAL
+        events: OPTIONAL

--- a/src/test/java/com/eventty/eventtynextgen/base/provider/JwtTokenProviderTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/provider/JwtTokenProviderTest.java
@@ -2,8 +2,7 @@ package com.eventty.eventtynextgen.base.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.eventty.eventtynextgen.base.provider.JwtTokenProvider;
-import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.TokenInfo;
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.AccessTokenInfo;
 import com.eventty.eventtynextgen.certification.constant.CertificationConst;
 import com.eventty.eventtynextgen.certification.core.Authentication;
 import com.eventty.eventtynextgen.certification.fixture.AuthenticationFixture;
@@ -34,7 +33,7 @@ class JwtTokenProviderTest {
             JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(SECRET_KEY, TOKEN_VALIDITY_IN_MIN, TOKEN_VALIDITY_IN_MIN);
 
             // when
-            TokenInfo token = jwtTokenProvider.createToken(authentication);
+            AccessTokenInfo token = jwtTokenProvider.createAccessToken(authentication);
 
             // then
             assertThat(token.getTokenType()).isEqualTo(CertificationConst.JWT_TOKEN_TYPE);
@@ -52,7 +51,7 @@ class JwtTokenProviderTest {
 
             // when & then
             try {
-                jwtTokenProvider.createToken(authentication);
+                jwtTokenProvider.createAccessToken(authentication);
             } catch (Exception ex) {
                 assertThat(ex.getClass()).isEqualTo(IllegalArgumentException.class);
                 assertThat(ex.getMessage()).isEqualTo("Only authorized users can generate a JWT token.");

--- a/src/test/java/com/eventty/eventtynextgen/certification/CertificationServiceImplTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/certification/CertificationServiceImplTest.java
@@ -7,14 +7,18 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.eventty.eventtynextgen.base.properties.AuthorizationApiProperties;
+import com.eventty.eventtynextgen.base.properties.AuthorizationApiProperties.Permission;
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider;
-import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.TokenInfo;
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.AccessTokenInfo;
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.CertificationTokenInfo;
 import com.eventty.eventtynextgen.certification.authentication.AuthenticationProvider;
 import com.eventty.eventtynextgen.certification.authorization.AuthorizationProvider;
 import com.eventty.eventtynextgen.certification.constant.CertificationConst;
 import com.eventty.eventtynextgen.certification.refreshtoken.RefreshTokenService;
 import com.eventty.eventtynextgen.certification.refreshtoken.entity.RefreshToken;
-import com.eventty.eventtynextgen.certification.response.CertificationReissueResponseView;
+import com.eventty.eventtynextgen.certification.response.CertificationIssueCertificationTokenResponseView;
+import com.eventty.eventtynextgen.certification.response.CertificationReissueAccessTokenResponseView;
 import com.eventty.eventtynextgen.shared.component.user.UserComponent;
 import com.eventty.eventtynextgen.shared.exception.CustomException;
 import com.eventty.eventtynextgen.shared.exception.enums.CertificationErrorType;
@@ -23,6 +27,7 @@ import com.eventty.eventtynextgen.user.entity.User;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -50,9 +55,13 @@ class CertificationServiceImplTest {
     @Mock
     private UserComponent userComponent;
 
+    @Mock
+    private AuthorizationApiProperties authorizationApiProperties;
+
+
     @Nested
-    @DisplayName("비즈니스 로직 - 토큰 재발급")
-    class Reissue {
+    @DisplayName("비즈니스 로직 - Access 토큰 재발급")
+    class ReissueAccessToken {
 
         @Test
         @DisplayName("저장되어 있는 유효한 RefreshToken을 이용한 토큰 재발급 요청은 `성공`한다")
@@ -65,21 +74,21 @@ class CertificationServiceImplTest {
             User user = mock(User.class);
 
             RefreshToken refreshTokenFromDb = mock(RefreshToken.class);
-            TokenInfo tokenInfo = createMockTokenInfo();
+            AccessTokenInfo tokenInfo = createMockTokenInfo();
 
             doNothing().when(jwtTokenProvider).verifyToken(refreshToken);
             when(refreshTokenService.getRefreshToken(userId)).thenReturn(refreshTokenFromDb);
             when(refreshTokenFromDb.getRefreshToken()).thenReturn(refreshToken);
             when(userComponent.findByUserId(userId)).thenReturn(Optional.of(user));
             when(user.isDeleted()).thenReturn(false);
-            when(jwtTokenProvider.createTokenByExpiredToken(expiredAccessToken)).thenReturn(tokenInfo);
+            when(jwtTokenProvider.createAccessTokenByExpiredToken(expiredAccessToken)).thenReturn(tokenInfo);
             when(refreshTokenService.saveOrUpdate(tokenInfo.getRefreshToken(), userId)).thenReturn(mock(RefreshToken.class));
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent);
+                refreshTokenService, userComponent, authorizationApiProperties);
 
             // when
-            CertificationReissueResponseView result = certificationService.reissue(userId, expiredAccessToken, refreshToken, response);
+            CertificationReissueAccessTokenResponseView result = certificationService.reissueAccessToken(userId, expiredAccessToken, refreshToken, response);
 
             // then
             assertThat(result.userId()).isEqualTo(userId);
@@ -99,11 +108,11 @@ class CertificationServiceImplTest {
             doThrow(ExpiredJwtException.class).when(jwtTokenProvider).verifyToken(expiredRefreshToken);
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent);
+                refreshTokenService, userComponent, authorizationApiProperties);
 
             // when & then
             assertThatThrownBy(() ->
-                certificationService.reissue(userId, expiredAccessToken, expiredRefreshToken, response))
+                certificationService.reissueAccessToken(userId, expiredAccessToken, expiredRefreshToken, response))
                 .extracting(ex -> ((CustomException) ex).getErrorType()).isEqualTo(CertificationErrorType.JWT_TOKEN_EXPIRED);
         }
 
@@ -119,11 +128,11 @@ class CertificationServiceImplTest {
             doThrow(IllegalStateException.class).when(jwtTokenProvider).verifyToken(expiredRefreshToken);
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent);
+                refreshTokenService, userComponent, authorizationApiProperties);
 
             // when & then
             assertThatThrownBy(() ->
-                certificationService.reissue(userId, expiredAccessToken, expiredRefreshToken, response))
+                certificationService.reissueAccessToken(userId, expiredAccessToken, expiredRefreshToken, response))
                 .extracting(ex -> ((CustomException) ex).getErrorType()).isEqualTo(CertificationErrorType.FAILED_TOKEN_VERIFIED);
         }
 
@@ -139,11 +148,11 @@ class CertificationServiceImplTest {
             doThrow(SignatureException.class).when(jwtTokenProvider).verifyToken(expiredRefreshToken);
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent);
+                refreshTokenService, userComponent, authorizationApiProperties);
 
             // when & then
             assertThatThrownBy(() ->
-                certificationService.reissue(userId, expiredAccessToken, expiredRefreshToken, response))
+                certificationService.reissueAccessToken(userId, expiredAccessToken, expiredRefreshToken, response))
                 .extracting(ex -> ((CustomException) ex).getErrorType()).isEqualTo(CertificationErrorType.FAILED_TOKEN_VERIFIED);
         }
 
@@ -160,11 +169,11 @@ class CertificationServiceImplTest {
             doThrow(CustomException.class).when(refreshTokenService).getRefreshToken(userId);
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent);
+                refreshTokenService, userComponent, authorizationApiProperties);
 
             // when & then
             assertThatThrownBy(() ->
-                certificationService.reissue(userId, expiredAccessToken, refreshToken, response))
+                certificationService.reissueAccessToken(userId, expiredAccessToken, refreshToken, response))
                 .isInstanceOf(CustomException.class);
         }
 
@@ -184,11 +193,11 @@ class CertificationServiceImplTest {
             when(refreshTokenFromDb.getRefreshToken()).thenReturn("mismatch_refresh_token");
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent);
+                refreshTokenService, userComponent, authorizationApiProperties);
 
             // when & then
             assertThatThrownBy(() ->
-                certificationService.reissue(userId, expiredAccessToken, refreshToken, response))
+                certificationService.reissueAccessToken(userId, expiredAccessToken, refreshToken, response))
                 .extracting(ex -> ((CustomException) ex).getErrorType()).isEqualTo(CertificationErrorType.MISMATCH_REFRESH_TOKEN);
         }
 
@@ -211,20 +220,67 @@ class CertificationServiceImplTest {
             when(user.isDeleted()).thenReturn(true);
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent);
+                refreshTokenService, userComponent, authorizationApiProperties);
 
             // when & then
             assertThatThrownBy(() ->
-                certificationService.reissue(userId, expiredAccessToken, refreshToken, response))
+                certificationService.reissueAccessToken(userId, expiredAccessToken, refreshToken, response))
                 .extracting(ex -> ((CustomException) ex).getErrorType()).isEqualTo(UserErrorType.USER_ALREADY_DELETED);
         }
 
-        private TokenInfo createMockTokenInfo() {
-            TokenInfo mock = mock(TokenInfo.class);
+        private AccessTokenInfo createMockTokenInfo() {
+            AccessTokenInfo mock = mock(AccessTokenInfo.class);
             when(mock.getTokenType()).thenReturn(CertificationConst.JWT_TOKEN_TYPE);
             when(mock.getAccessToken()).thenReturn("new_access_token");
             when(mock.getRefreshToken()).thenReturn("new_refresh_token");
             return mock;
+        }
+    }
+
+    @Nested
+    @DisplayName("비즈니스 로직 - Certification 토큰 발급")
+    class IssueCertificationToken {
+
+        @Test
+        @DisplayName("올바른 APP Name이 들어올 경우 토큰 발급에 성공한다.")
+        void 올바른_APP_NAME이_들어올_경우_토큰_발급에_성공한다() {
+            // given
+            String appName = "testAppName";
+            Map<String, Permission> apiPermissions = Map.of("all", Permission.FREE);
+            CertificationTokenInfo certificationTokenInfo = mock(CertificationTokenInfo.class);
+
+            when(authorizationApiProperties.containsAppName(appName)).thenReturn(true);
+            when(authorizationApiProperties.getPermissions(appName)).thenReturn(apiPermissions);
+            when(jwtTokenProvider.createCertificationToken(appName, apiPermissions)).thenReturn(certificationTokenInfo);
+
+            CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
+                refreshTokenService, userComponent,
+                authorizationApiProperties);
+
+            // when
+            CertificationIssueCertificationTokenResponseView certificationIssueCertificationTokenResponseView = certificationService.issueCertificationToken(
+                appName);
+
+            // then
+            assertThat(certificationIssueCertificationTokenResponseView.certificationToken()).isEqualTo(certificationTokenInfo);
+        }
+
+        @Test
+        @DisplayName("APP Name을 찾을 수 없는 경우 토큰 발급에 실패한다")
+        void APP_NAME을_찾을_수_없는_경우_토큰_발급에_실패한다() {
+            // given
+            String appName = "testAppName";
+
+            when(authorizationApiProperties.containsAppName(appName)).thenReturn(false);
+
+            CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
+                refreshTokenService, userComponent,
+                authorizationApiProperties);
+
+            // when & then
+            assertThatThrownBy(() ->
+                certificationService.issueCertificationToken(appName))
+                .extracting(ex -> ((CustomException) ex).getErrorType()).isEqualTo(CertificationErrorType.NOT_FOUND_APP_NAME);
         }
     }
 }

--- a/src/test/java/com/eventty/eventtynextgen/certification/CertificationServiceImplTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/certification/CertificationServiceImplTest.java
@@ -14,6 +14,7 @@ import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.AccessTokenInfo
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.CertificationTokenInfo;
 import com.eventty.eventtynextgen.certification.authentication.AuthenticationProvider;
 import com.eventty.eventtynextgen.certification.authorization.AuthorizationProvider;
+import com.eventty.eventtynextgen.certification.authuser.AuthUserService;
 import com.eventty.eventtynextgen.certification.constant.CertificationConst;
 import com.eventty.eventtynextgen.certification.refreshtoken.RefreshTokenService;
 import com.eventty.eventtynextgen.certification.refreshtoken.entity.RefreshToken;
@@ -58,6 +59,9 @@ class CertificationServiceImplTest {
     @Mock
     private AuthorizationApiProperties authorizationApiProperties;
 
+    @Mock
+    private AuthUserService authUserService;
+
 
     @Nested
     @DisplayName("비즈니스 로직 - Access 토큰 재발급")
@@ -81,11 +85,11 @@ class CertificationServiceImplTest {
             when(refreshTokenFromDb.getRefreshToken()).thenReturn(refreshToken);
             when(userComponent.findByUserId(userId)).thenReturn(Optional.of(user));
             when(user.isDeleted()).thenReturn(false);
-            when(jwtTokenProvider.createAccessTokenByExpiredToken(expiredAccessToken)).thenReturn(tokenInfo);
+            when(jwtTokenProvider.createAccessTokenByExpiredToken()).thenReturn(tokenInfo);
             when(refreshTokenService.saveOrUpdate(tokenInfo.getRefreshToken(), userId)).thenReturn(mock(RefreshToken.class));
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent, authorizationApiProperties);
+                refreshTokenService, userComponent, authorizationApiProperties, authUserService);
 
             // when
             CertificationReissueAccessTokenResponseView result = certificationService.reissueAccessToken(userId, expiredAccessToken, refreshToken, response);
@@ -108,7 +112,7 @@ class CertificationServiceImplTest {
             doThrow(ExpiredJwtException.class).when(jwtTokenProvider).verifyToken(expiredRefreshToken);
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent, authorizationApiProperties);
+                refreshTokenService, userComponent, authorizationApiProperties, authUserService);
 
             // when & then
             assertThatThrownBy(() ->
@@ -128,7 +132,7 @@ class CertificationServiceImplTest {
             doThrow(IllegalStateException.class).when(jwtTokenProvider).verifyToken(expiredRefreshToken);
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent, authorizationApiProperties);
+                refreshTokenService, userComponent, authorizationApiProperties, authUserService);
 
             // when & then
             assertThatThrownBy(() ->
@@ -148,7 +152,7 @@ class CertificationServiceImplTest {
             doThrow(SignatureException.class).when(jwtTokenProvider).verifyToken(expiredRefreshToken);
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent, authorizationApiProperties);
+                refreshTokenService, userComponent, authorizationApiProperties, authUserService);
 
             // when & then
             assertThatThrownBy(() ->
@@ -169,7 +173,7 @@ class CertificationServiceImplTest {
             doThrow(CustomException.class).when(refreshTokenService).getRefreshToken(userId);
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent, authorizationApiProperties);
+                refreshTokenService, userComponent, authorizationApiProperties, authUserService);
 
             // when & then
             assertThatThrownBy(() ->
@@ -193,7 +197,7 @@ class CertificationServiceImplTest {
             when(refreshTokenFromDb.getRefreshToken()).thenReturn("mismatch_refresh_token");
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent, authorizationApiProperties);
+                refreshTokenService, userComponent, authorizationApiProperties, authUserService);
 
             // when & then
             assertThatThrownBy(() ->
@@ -220,7 +224,7 @@ class CertificationServiceImplTest {
             when(user.isDeleted()).thenReturn(true);
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent, authorizationApiProperties);
+                refreshTokenService, userComponent, authorizationApiProperties, authUserService);
 
             // when & then
             assertThatThrownBy(() ->
@@ -254,8 +258,7 @@ class CertificationServiceImplTest {
             when(jwtTokenProvider.createCertificationToken(appName, apiPermissions)).thenReturn(certificationTokenInfo);
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent,
-                authorizationApiProperties);
+                refreshTokenService, userComponent, authorizationApiProperties, authUserService);
 
             // when
             CertificationIssueCertificationTokenResponseView certificationIssueCertificationTokenResponseView = certificationService.issueCertificationToken(
@@ -274,8 +277,7 @@ class CertificationServiceImplTest {
             when(authorizationApiProperties.containsAppName(appName)).thenReturn(false);
 
             CertificationServiceImpl certificationService = new CertificationServiceImpl(authenticationProvider, authorizationProvider, jwtTokenProvider,
-                refreshTokenService, userComponent,
-                authorizationApiProperties);
+                refreshTokenService, userComponent, authorizationApiProperties, authUserService);
 
             // when & then
             assertThatThrownBy(() ->


### PR DESCRIPTION
## :bell: Related issues <!-- Please write #[issue_number] -->

#62

## :pencil: Changes and Reasons <!-- Please list what you have changed and why. -->

- Certification Token을 이용하여 API를 호출하는 APP 검증을 수행해야 하므로 토큰 생성 API를 구현
- Login 로직 수정
  - Access Token에 사용자 정보를 저장하는 방식 -> Access Token은 Session ID 용도로 사용하며 사용자 정보는 DB에 영속화

## :sparkles: PR Point <!-- what you want reviewers to focus on -->

N/A

## :gift: Notes

N/A
