### PR TITLE
[ISSUE-#82] API 호출 세부 권한은 삭제하고 API 호출 권한만 확인하도록 변경

### DIFF
--- a/src/main/java/com/eventty/eventtynextgen/base/filter/ApiPermissionVerifiedFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/ApiPermissionVerifiedFilter.java
@@ -3,7 +3,6 @@ package com.eventty.eventtynextgen.base.filter;
 import com.eventty.eventtynextgen.base.enums.ApiName;
 import com.eventty.eventtynextgen.base.utils.ResponseUtils;
 import com.eventty.eventtynextgen.certification.component.CertificationManager;
-import com.eventty.eventtynextgen.config.properties.CertificationApiProperties.Permission;
 import com.eventty.eventtynextgen.shared.context.CertificationContext;
 import com.eventty.eventtynextgen.shared.context.CertificationContextHolder;
 import com.eventty.eventtynextgen.shared.context.SessionContextHolder;
@@ -15,9 +14,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
@@ -40,7 +39,6 @@ public class ApiPermissionVerifiedFilter extends OncePerRequestFilter {
         // 1. Context.isSkipCertificate 값이 true일 경우 다음 Filter로 넘긴다
         CertificationContext context = CertificationContextHolder.getContext();
         if (context.isSkipCertificate()) {
-            SessionContextHolder.getContext().markSessionCheckAsSkipped();
             filterChain.doFilter(request, response);
             return;
         }
@@ -66,11 +64,6 @@ public class ApiPermissionVerifiedFilter extends OncePerRequestFilter {
             return;
         }
 
-        // 6. Permission을 확인하여 FREE, OPTIONAL인 경우 SessionContext의 SkipSessionCheck을 true로 마킹한다
-        if (shouldSkipSessionCheck(apiName, context.getApiPermissionMap())) {
-            SessionContextHolder.getContext().markSessionCheckAsSkipped();
-        }
-
         filterChain.doFilter(request, response);
     }
 
@@ -89,7 +82,7 @@ public class ApiPermissionVerifiedFilter extends OncePerRequestFilter {
     }
 
     private boolean isTokenPayloadUpdatedInContext(CertificationContext context) {
-        return StringUtils.hasText(context.getAppName()) && Objects.nonNull(context.getApiPermissionMap());
+        return StringUtils.hasText(context.getAppName()) && Objects.nonNull(context.getApiPermission());
     }
 
     private ApiName resolveApiName(String requestURI, HttpServletResponse response) {
@@ -108,10 +101,10 @@ public class ApiPermissionVerifiedFilter extends OncePerRequestFilter {
     }
 
     private boolean validateApiPermissionInToken(ApiName apiName, CertificationContext context, HttpServletResponse response) {
-        Map<String, Permission> apiPermissionByToken = context.getApiPermissionMap();
+        Set<String> apiPermissionByToken = context.getApiPermission();
         String key = apiName.name().toLowerCase();
 
-        if (!apiPermissionByToken.containsKey(key)) {
+        if (!apiPermissionByToken.contains(key)) {
             CustomException customException = CustomException.of(HttpStatus.FORBIDDEN, CertificationErrorType.NO_API_CALL_PERMISSION_IN_TOKEN);
             writeErrorResponse(customException, response);
             return false;
@@ -121,21 +114,16 @@ public class ApiPermissionVerifiedFilter extends OncePerRequestFilter {
     }
 
     private boolean validateApiPermissionByYaml(ApiName apiName, String appName, HttpServletResponse response) {
-        Map<String, Permission> apiPermissionByYaml = this.certificationManager.findApiPermission(appName);
+        Set<String> apiPermissionByYaml = this.certificationManager.findApiPermission(appName);
         String key = apiName.name().toLowerCase();
 
-        if (!apiPermissionByYaml.containsKey(key)) {
+        if (!apiPermissionByYaml.contains(key)) {
             CustomException customException = CustomException.of(HttpStatus.FORBIDDEN, CertificationErrorType.NO_API_CALL_PERMISSION_IN_YAML);
             writeErrorResponse(customException, response);
             return false;
         }
 
         return true;
-    }
-
-    public boolean shouldSkipSessionCheck(ApiName apiName, Map<String, Permission> apiPermissionMap) {
-        Permission permission = apiPermissionMap.get(apiName.name().toLowerCase());
-        return permission != Permission.LOGIN;
     }
 
     private void writeErrorResponse(CustomException customException, HttpServletResponse response) {

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/CertificationTokenFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/CertificationTokenFilter.java
@@ -28,7 +28,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class CertificationTokenFilter extends OncePerRequestFilter {
 
     private static final List<String> SKIP_PATTERNS = List.of(
-        "/swagger-ui", "/v3/api-docs", "/health", "/api/*/certification"
+        "/swagger-ui/**", "/v3/api-docs/**", "/health/**", "/api/*/certification/**"
     );
 
     @Override
@@ -70,7 +70,7 @@ public class CertificationTokenFilter extends OncePerRequestFilter {
         CertificationTokenPayload payload = JwtTokenProvider.retrieveCertificationToken(token);
         context.updateFromTokenClaims(
             payload.getAppName(),
-            payload.getApiPermissionMap(),
+            payload.getApiPermission(),
             payload.getAdminEmail()
         );
     }

--- a/src/main/java/com/eventty/eventtynextgen/base/provider/JwtTokenProvider.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/provider/JwtTokenProvider.java
@@ -8,9 +8,7 @@ import static com.eventty.eventtynextgen.base.constant.BaseConst.JWT_SECRET_KEY;
 import static com.eventty.eventtynextgen.base.constant.BaseConst.JWT_TOKEN_TYPE;
 import static com.eventty.eventtynextgen.base.constant.BaseConst.OBJECT_MAPPER;
 
-import com.eventty.eventtynextgen.config.properties.CertificationApiProperties.Permission;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -21,6 +19,7 @@ import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import java.util.Date;
 import java.util.Map;
+import java.util.Set;
 import javax.crypto.SecretKey;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -105,11 +104,11 @@ public class JwtTokenProvider {
         }
     }
 
-    public static CertificationTokenInfo createCertificationToken(String appName, Map<String, Permission> apiPermissionMap, long certificationTokenValidityInMS) {
+    public static CertificationTokenInfo createCertificationToken(String appName, Set<String> apiPermission, long certificationTokenValidityInMS) {
         long now = new Date(System.currentTimeMillis()).getTime();
         Map<String, Object> claims = Map.of(APP_NAME_KEY, appName,
             ADMIN_EMAIL_KEY, "jeongbeom4693@gmail.com",
-            API_ALLOW_KEY, apiPermissionMap);
+            API_ALLOW_KEY, apiPermission);
 
         String certificationToken = Jwts.builder()
             .addClaims(claims)
@@ -127,16 +126,16 @@ public class JwtTokenProvider {
         String adminEmail = claims.get(ADMIN_EMAIL_KEY, String.class);
 
         Object rawApiPermission = claims.get(API_ALLOW_KEY);
-        Map<String, Permission> apiPermissionMap = OBJECT_MAPPER.convertValue(rawApiPermission, new TypeReference<>() {});
+        Set<String> apiPermission = OBJECT_MAPPER.convertValue(rawApiPermission, new TypeReference<>() {});
 
-        return new CertificationTokenPayload(appName, apiPermissionMap, adminEmail);
+        return new CertificationTokenPayload(appName, apiPermission, adminEmail);
     }
 
     @Getter
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class CertificationTokenPayload {
         private String appName;
-        private Map<String, Permission> apiPermissionMap;
+        private Set<String> apiPermission;
         private String adminEmail;
     }
 

--- a/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/CertificationServiceImpl.java
@@ -6,12 +6,11 @@ import static com.eventty.eventtynextgen.certification.constant.CertificationCon
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider;
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.CertificationTokenInfo;
 import com.eventty.eventtynextgen.certification.component.CertificationManager;
-import com.eventty.eventtynextgen.config.properties.CertificationApiProperties.Permission;
 import com.eventty.eventtynextgen.shared.exception.CustomException;
 import com.eventty.eventtynextgen.shared.exception.enums.CertificationErrorType;
 import com.eventty.eventtynextgen.shared.utils.CookieUtils;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,14 +34,14 @@ public class CertificationServiceImpl implements CertificationService {
             throw CustomException.badRequest(CertificationErrorType.MISMATCH_SECRET_KEY);
         }
 
-        // 3. Api Allow List 가져오기
-        Map<String, Permission> apiPermissions = this.certificationManager.findApiPermission(appName);
-        if (apiPermissions.isEmpty()) {
+        // 3. Api Allow Set 가져오기
+        Set<String> apiPermission = this.certificationManager.findApiPermission(appName);
+        if (apiPermission.isEmpty()) {
             log.warn("appName의 API 호출 권한 리스트가 빈 상태로 발급되었습니다. appName: {}", appName);
         }
 
         // 4. Certification Token 발급
-        CertificationTokenInfo certificationToken = JwtTokenProvider.createCertificationToken(appName, apiPermissions, CERTIFICATION_TOKEN_VALIDITY_IN_MS);
+        CertificationTokenInfo certificationToken = JwtTokenProvider.createCertificationToken(appName, apiPermission, CERTIFICATION_TOKEN_VALIDITY_IN_MS);
 
         // 5. 생성한 토큰 쿠키에 담기
         CookieUtils.addLaxCookie(CERTIFICATION_TOKEN_COOKIE_NAME, certificationToken.getCertificationToken(), CERTIFICATION_TOKEN_VALIDITY_IN_MS / 1000,

--- a/src/main/java/com/eventty/eventtynextgen/certification/component/CertificationManager.java
+++ b/src/main/java/com/eventty/eventtynextgen/certification/component/CertificationManager.java
@@ -1,10 +1,8 @@
 package com.eventty.eventtynextgen.certification.component;
 
 import com.eventty.eventtynextgen.config.properties.CertificationApiProperties;
-import com.eventty.eventtynextgen.config.properties.CertificationApiProperties.Permission;
 import com.eventty.eventtynextgen.config.properties.CertificationSecretProperties;
-import java.util.Collections;
-import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -16,14 +14,11 @@ public class CertificationManager {
     private final CertificationApiProperties certificationApiProperties;
 
     public boolean hasAppName(String appName) {
-        return this.certificationSecretProperties.getCertificationSecrets().containsKey(appName) && this.certificationApiProperties.getInfoMap().containsKey(appName);
+        return this.certificationSecretProperties.getCertificationSecrets().containsKey(appName) && this.certificationApiProperties.getApiPermissionMap().containsKey(appName);
     }
 
-    public Map<String, Permission> findApiPermission(String appName) {
-        if (hasAppName(appName)) {
-            return this.certificationApiProperties.getInfoMap().get(appName).getApiPermissions();
-        }
-        return Collections.emptyMap();
+    public Set<String> findApiPermission(String appName) {
+        return this.certificationApiProperties.getApiPermissionMap().get(appName);
     }
 
     public boolean matchesSecretKey(String appName, String appSecret) {

--- a/src/main/java/com/eventty/eventtynextgen/config/properties/CertificationApiProperties.java
+++ b/src/main/java/com/eventty/eventtynextgen/config/properties/CertificationApiProperties.java
@@ -1,6 +1,7 @@
 package com.eventty.eventtynextgen.config.properties;
 
 import java.util.Map;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -12,19 +13,6 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "certification")
 public class CertificationApiProperties {
 
-    private Map<String, ApiPermission> infoMap;
-
-    @Getter
-    @Setter
-    public static class ApiPermission {
-        private Map<String, Permission> apiPermissions;
-    }
-
-    @Getter
-    public enum Permission {
-        FREE,
-        LOGIN,
-        OPTIONAL
-    }
+    private Map<String, Set<String>> apiPermissionMap;
 }
 

--- a/src/main/java/com/eventty/eventtynextgen/shared/context/CertificationContext.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/context/CertificationContext.java
@@ -1,7 +1,6 @@
 package com.eventty.eventtynextgen.shared.context;
 
-import com.eventty.eventtynextgen.config.properties.CertificationApiProperties.Permission;
-import java.util.Map;
+import java.util.Set;
 import lombok.Getter;
 
 @Getter
@@ -9,7 +8,7 @@ public class CertificationContext {
 
     private boolean skipCertificate;
     private String appName;
-    private Map<String, Permission> apiPermissionMap;
+    private Set<String> apiPermission;
     private String adminEmail;
     private String tokenParsingFailureReason;
 
@@ -21,9 +20,9 @@ public class CertificationContext {
         this.skipCertificate = true;
     }
 
-    public void updateFromTokenClaims(String appName, Map<String, Permission> apiPermissionMap, String adminEmail) {
+    public void updateFromTokenClaims(String appName, Set<String> apiPermission, String adminEmail) {
         this.appName = appName;
-        this.apiPermissionMap = apiPermissionMap;
+        this.apiPermission = apiPermission;
         this.adminEmail = adminEmail;
     }
 

--- a/src/main/java/com/eventty/eventtynextgen/shared/context/SessionContext.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/context/SessionContext.java
@@ -9,7 +9,6 @@ public class SessionContext {
 
     private Long userId;
     private String role;
-    private boolean skipSessionCheck;
 
     public SessionContext() {}
 
@@ -20,9 +19,5 @@ public class SessionContext {
 
     public boolean validate() {
         return Objects.nonNull(this.userId) && StringUtils.hasText(role);
-    }
-
-    public void markSessionCheckAsSkipped() {
-        this.skipSessionCheck = true;
     }
 }

--- a/src/main/resources/application-certification-test.yml
+++ b/src/main/resources/application-certification-test.yml
@@ -1,10 +1,8 @@
 certification:
-  infoMap:
+  api-permission-map:
     client1:
-      api-permissions:
-        user: FREE
-        events: LOGIN
-        auth: OPTIONAL
+      - user
+      - events
+      - auth
     client2:
-      api-permissions:
-        events: OPTIONAL
+      - events

--- a/src/main/resources/application-certification.yml
+++ b/src/main/resources/application-certification.yml
@@ -1,13 +1,11 @@
 certification:
-  infoMap:
+  api-permission-map:
     client-app0:
-      api-permissions:
-        user: OPTIONAL
-        events: OPTIONAL
+      - user
+      - events
 
-        auth_code: FREE
-        auth_login: FREE
-        auth: LOGIN
+      - auth_code
+      - auth_login
+      - auth
     client-app1:
-      api-permissions:
-        events: OPTIONAL
+      - events

--- a/src/test/java/com/eventty/eventtynextgen/base/filter/ApiPermissionVerifiedFilterTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/filter/ApiPermissionVerifiedFilterTest.java
@@ -1,6 +1,5 @@
 package com.eventty.eventtynextgen.base.filter;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -10,10 +9,8 @@ import static org.mockito.Mockito.when;
 
 import com.eventty.eventtynextgen.base.utils.ResponseUtils;
 import com.eventty.eventtynextgen.certification.component.CertificationManager;
-import com.eventty.eventtynextgen.config.properties.CertificationApiProperties.Permission;
 import com.eventty.eventtynextgen.shared.context.CertificationContext;
 import com.eventty.eventtynextgen.shared.context.CertificationContextHolder;
-import com.eventty.eventtynextgen.shared.context.SessionContext;
 import com.eventty.eventtynextgen.shared.context.SessionContextHolder;
 import com.eventty.eventtynextgen.shared.exception.CustomException;
 import jakarta.servlet.FilterChain;
@@ -21,7 +18,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,8 +43,8 @@ class ApiPermissionVerifiedFilterTest {
     }
 
     @Test
-    @DisplayName("API 호출 권한 검증을 SKIP 해야하는 경우 Skip Session Check를 마킹한 뒤 통과한다")
-    void API_호출_권한_검증을_SKIP_해야하는_경우_SKIP_SESSION_CHECK를_마킹한_뒤_통과한다() throws ServletException, IOException {
+    @DisplayName("API 호출 권한 검증을 SKIP 해야하는 경우 곧바로 다음 필터로 넘어간다")
+    void API_호출_권한_검증을_SKIP_해야하는_경우_곧바로_다음_필터로_넘어간다() throws ServletException, IOException {
         // given
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
@@ -62,23 +59,20 @@ class ApiPermissionVerifiedFilterTest {
 
         // then
         verify(filterChain, times(1)).doFilter(request, response);
-
-        SessionContext sessionContext = SessionContextHolder.getContext();
-        assertThat(sessionContext.isSkipSessionCheck()).isTrue();
     }
 
     @Test
-    @DisplayName("모든 검증을 성공적으로 통과하고 권한이 FREE인 경우 세션 검증을 스킵하도록 마킹한다")
-    void 모든_검증을_성공적으로_통과하고_권한이_FREE인_경우_세션_검증을_통과하도록_마킹한다() throws ServletException, IOException {
+    @DisplayName("모든 검증을 성공적으로 통과하면 다음 필터로 넘어간다")
+    void 모든_검증을_성공적으로_통과하면_다음_필터로_넘어간다() throws ServletException, IOException {
         // given
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
         FilterChain filterChain = mock(FilterChain.class);
 
         CertificationContext context = CertificationContextHolder.getContext();
-        context.updateFromTokenClaims("client", Map.of("user", Permission.FREE), "adminEmail@gmail.com");
+        context.updateFromTokenClaims("client", Set.of("user"), "adminEmail@gmail.com");
         when(request.getRequestURI()).thenReturn("/api/v1/user");
-        when(certificationManager.findApiPermission(context.getAppName())).thenReturn(Map.of("user", Permission.FREE));
+        when(certificationManager.findApiPermission(context.getAppName())).thenReturn(Set.of("user"));
 
         ApiPermissionVerifiedFilter apiPermissionVerifiedFilter = new ApiPermissionVerifiedFilter(certificationManager, responseUtils);
 
@@ -87,59 +81,6 @@ class ApiPermissionVerifiedFilterTest {
 
         // then
         verify(filterChain, times(1)).doFilter(request, response);
-
-        SessionContext sessionContext = SessionContextHolder.getContext();
-        assertThat(sessionContext.isSkipSessionCheck()).isTrue();
-    }
-
-    @Test
-    @DisplayName("모든 검증을 성공적으로 통과하고 권한이 OPTIONAL인 경우 세션 검증을 스킵하도록 마킹한다")
-    void 모든_검증을_성공적으로_통과하고_권한이_OPTIONAL인_경우_세션_검증을_통과하도록_마킹한다() throws ServletException, IOException {
-        // given
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        HttpServletResponse response = mock(HttpServletResponse.class);
-        FilterChain filterChain = mock(FilterChain.class);
-
-        CertificationContext context = CertificationContextHolder.getContext();
-        context.updateFromTokenClaims("client", Map.of("user", Permission.OPTIONAL), "adminEmail@gmail.com");
-        when(request.getRequestURI()).thenReturn("/api/v1/user");
-        when(certificationManager.findApiPermission(context.getAppName())).thenReturn(Map.of("user", Permission.OPTIONAL));
-
-        ApiPermissionVerifiedFilter apiPermissionVerifiedFilter = new ApiPermissionVerifiedFilter(certificationManager, responseUtils);
-
-        // when
-        apiPermissionVerifiedFilter.doFilterInternal(request, response, filterChain);
-
-        // then
-        verify(filterChain, times(1)).doFilter(request, response);
-
-        SessionContext sessionContext = SessionContextHolder.getContext();
-        assertThat(sessionContext.isSkipSessionCheck()).isTrue();
-    }
-
-    @Test
-    @DisplayName("모든 검증을 성공적으로 통과하고 권한이 LOGIN인 경우 세션 검증을 스킵하지 않도록 마킹하지 않는다")
-    void 모든_검증을_성공적으로_통과하고_권한이_LOGIN인_경우_세션_검증을_스킵하지_않도록_마킹하지_않는다() throws ServletException, IOException {
-        // given
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        HttpServletResponse response = mock(HttpServletResponse.class);
-        FilterChain filterChain = mock(FilterChain.class);
-
-        CertificationContext context = CertificationContextHolder.getContext();
-        context.updateFromTokenClaims("client", Map.of("user", Permission.LOGIN), "adminEmail@gmail.com");
-        when(request.getRequestURI()).thenReturn("/api/v1/user");
-        when(certificationManager.findApiPermission(context.getAppName())).thenReturn(Map.of("user", Permission.LOGIN));
-
-        ApiPermissionVerifiedFilter apiPermissionVerifiedFilter = new ApiPermissionVerifiedFilter(certificationManager, responseUtils);
-
-        // when
-        apiPermissionVerifiedFilter.doFilterInternal(request, response, filterChain);
-
-        // then
-        verify(filterChain, times(1)).doFilter(request, response);
-
-        SessionContext sessionContext = SessionContextHolder.getContext();
-        assertThat(sessionContext.isSkipSessionCheck()).isFalse();
     }
 
     @Test
@@ -173,7 +114,7 @@ class ApiPermissionVerifiedFilterTest {
         FilterChain filterChain = mock(FilterChain.class);
 
         CertificationContext context = CertificationContextHolder.getContext();
-        context.updateFromTokenClaims("client", Map.of("user", Permission.FREE), "adminEmail@gmail.com");
+        context.updateFromTokenClaims("client", Set.of("user"), "adminEmail@gmail.com");
 
         when(request.getRequestURI()).thenReturn("/nothing-match-url");
         doNothing().when(responseUtils).writeErrorResponseToResponse(any(HttpServletResponse.class), any(CustomException.class));
@@ -196,7 +137,7 @@ class ApiPermissionVerifiedFilterTest {
         FilterChain filterChain = mock(FilterChain.class);
 
         CertificationContext context = CertificationContextHolder.getContext();
-        context.updateFromTokenClaims("client", Map.of("auth", Permission.FREE), "adminEmail@gmail.com");
+        context.updateFromTokenClaims("client", Set.of("auth"), "adminEmail@gmail.com");
         when(request.getRequestURI()).thenReturn("/api/v1/user");
         doNothing().when(responseUtils).writeErrorResponseToResponse(any(HttpServletResponse.class), any(CustomException.class));
 
@@ -218,9 +159,9 @@ class ApiPermissionVerifiedFilterTest {
         FilterChain filterChain = mock(FilterChain.class);
 
         CertificationContext context = CertificationContextHolder.getContext();
-        context.updateFromTokenClaims("client", Map.of("user", Permission.FREE), "adminEmail@gmail.com");
+        context.updateFromTokenClaims("client", Set.of("user"), "adminEmail@gmail.com");
         when(request.getRequestURI()).thenReturn("/api/v1/user");
-        when(certificationManager.findApiPermission(context.getAppName())).thenReturn(Map.of("auth", Permission.FREE));
+        when(certificationManager.findApiPermission(context.getAppName())).thenReturn(Set.of("auth"));
         doNothing().when(responseUtils).writeErrorResponseToResponse(any(HttpServletResponse.class), any(CustomException.class));
 
         ApiPermissionVerifiedFilter apiPermissionVerifiedFilter = new ApiPermissionVerifiedFilter(certificationManager, responseUtils);

--- a/src/test/java/com/eventty/eventtynextgen/base/filter/CertificationTokenFilterTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/filter/CertificationTokenFilterTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import com.eventty.eventtynextgen.base.fixture.CertificationTokenFixture;
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.CertificationTokenInfo;
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.VerifyTokenResult;
-import com.eventty.eventtynextgen.config.properties.CertificationApiProperties.Permission;
 import com.eventty.eventtynextgen.shared.context.CertificationContext;
 import com.eventty.eventtynextgen.shared.context.CertificationContextHolder;
 import jakarta.servlet.FilterChain;
@@ -17,7 +16,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,8 +34,8 @@ class CertificationTokenFilterTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
         FilterChain filterChain = mock(FilterChain.class);
 
-        Map<String, Permission> apiPermissionMap = Map.of("user", Permission.OPTIONAL);
-        CertificationTokenInfo tokenInfo = CertificationTokenFixture.createCertificationToken("client", apiPermissionMap);
+        Set<String> apiPermission = Set.of("user");
+        CertificationTokenInfo tokenInfo = CertificationTokenFixture.createCertificationToken("client", apiPermission);
         String rawToken = tokenInfo.getCertificationToken();
 
         when(request.getRequestURI()).thenReturn("/api/v1/user");
@@ -46,7 +45,7 @@ class CertificationTokenFilterTest {
             // doFilter() 직전에 Context 상태 확인
             CertificationContext context = CertificationContextHolder.getContext();
             assertThat(context.getAppName()).isEqualTo("client");
-            assertThat(context.getApiPermissionMap().get("user")).isEqualTo(Permission.OPTIONAL);
+            assertThat(context.getApiPermission().contains("user")).isEqualTo(true);
             assertThat(context.getAdminEmail()).isNotBlank();
             assertThat(context.isSkipCertificate()).isFalse();
             assertThat(context.getTokenParsingFailureReason()).isNull();
@@ -61,7 +60,7 @@ class CertificationTokenFilterTest {
 
         // then
         assertThat(CertificationContextHolder.getContext().getAppName()).isNull();
-        assertThat(CertificationContextHolder.getContext().getApiPermissionMap()).isNull();
+        assertThat(CertificationContextHolder.getContext().getApiPermission()).isNull();
         assertThat(CertificationContextHolder.getContext().getAdminEmail()).isNull();
     }
 
@@ -79,7 +78,7 @@ class CertificationTokenFilterTest {
             // doFilter() 직전에 Context 상태 확인
             CertificationContext context = CertificationContextHolder.getContext();
             assertThat(context.getAppName()).isNull();
-            assertThat(context.getApiPermissionMap()).isNull();
+            assertThat(context.getApiPermission()).isNull();
             assertThat(context.getAdminEmail()).isNull();
             assertThat(context.isSkipCertificate()).isTrue();
             assertThat(context.getTokenParsingFailureReason()).isNull();
@@ -94,7 +93,7 @@ class CertificationTokenFilterTest {
 
         // then
         assertThat(CertificationContextHolder.getContext().getAppName()).isNull();
-        assertThat(CertificationContextHolder.getContext().getApiPermissionMap()).isNull();
+        assertThat(CertificationContextHolder.getContext().getApiPermission()).isNull();
         assertThat(CertificationContextHolder.getContext().getAdminEmail()).isNull();
     }
 
@@ -113,7 +112,7 @@ class CertificationTokenFilterTest {
             // doFilter() 직전에 Context 상태 확인
             CertificationContext context = CertificationContextHolder.getContext();
             assertThat(context.getAppName()).isNull();
-            assertThat(context.getApiPermissionMap()).isNull();
+            assertThat(context.getApiPermission()).isNull();
             assertThat(context.getAdminEmail()).isNull();
             assertThat(context.isSkipCertificate()).isFalse();
             assertThat(context.getTokenParsingFailureReason()).isNull();
@@ -128,7 +127,7 @@ class CertificationTokenFilterTest {
 
         // then
         assertThat(CertificationContextHolder.getContext().getAppName()).isNull();
-        assertThat(CertificationContextHolder.getContext().getApiPermissionMap()).isNull();
+        assertThat(CertificationContextHolder.getContext().getApiPermission()).isNull();
         assertThat(CertificationContextHolder.getContext().getAdminEmail()).isNull();
     }
 
@@ -140,8 +139,8 @@ class CertificationTokenFilterTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
         FilterChain filterChain = mock(FilterChain.class);
 
-        Map<String, Permission> apiPermissionMap = Map.of("user", Permission.OPTIONAL);
-        CertificationTokenInfo expiredToken = CertificationTokenFixture.createExpiredCertificationToken("client", apiPermissionMap);
+        Set<String> apiPermission = Set.of("user");
+        CertificationTokenInfo expiredToken = CertificationTokenFixture.createExpiredCertificationToken("client", apiPermission);
 
         when(request.getRequestURI()).thenReturn("/api/v1/user");
         when(request.getHeader(CERTIFICATION_TOKEN_COOKIE_NAME)).thenReturn(expiredToken.getCertificationToken());
@@ -150,7 +149,7 @@ class CertificationTokenFilterTest {
             // doFilter() 직전에 Context 상태 확인
             CertificationContext context = CertificationContextHolder.getContext();
             assertThat(context.getAppName()).isNull();
-            assertThat(context.getApiPermissionMap()).isNull();
+            assertThat(context.getApiPermission()).isNull();
             assertThat(context.getAdminEmail()).isNull();
             assertThat(context.isSkipCertificate()).isFalse();
             assertThat(context.getTokenParsingFailureReason()).isEqualTo(VerifyTokenResult.EXPIRED_TOKEN.name());
@@ -165,7 +164,7 @@ class CertificationTokenFilterTest {
 
         // then
         assertThat(CertificationContextHolder.getContext().getAppName()).isNull();
-        assertThat(CertificationContextHolder.getContext().getApiPermissionMap()).isNull();
+        assertThat(CertificationContextHolder.getContext().getApiPermission()).isNull();
         assertThat(CertificationContextHolder.getContext().getAdminEmail()).isNull();
     }
 }

--- a/src/test/java/com/eventty/eventtynextgen/base/fixture/CertificationTokenFixture.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/fixture/CertificationTokenFixture.java
@@ -2,16 +2,15 @@ package com.eventty.eventtynextgen.base.fixture;
 
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider;
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.CertificationTokenInfo;
-import com.eventty.eventtynextgen.config.properties.CertificationApiProperties.Permission;
-import java.util.Map;
+import java.util.Set;
 
 public class CertificationTokenFixture {
 
-    public static CertificationTokenInfo createCertificationToken(String appName, Map<String, Permission> apiPermissionMap) {
-        return JwtTokenProvider.createCertificationToken(appName, apiPermissionMap, 60 * 60 * 1000);
+    public static CertificationTokenInfo createCertificationToken(String appName, Set<String> apiPermission) {
+        return JwtTokenProvider.createCertificationToken(appName, apiPermission, 60 * 60 * 1000);
     }
 
-    public static CertificationTokenInfo createExpiredCertificationToken(String appName, Map<String, Permission> apiPermissionMap) {
-        return JwtTokenProvider.createCertificationToken(appName, apiPermissionMap, -10);
+    public static CertificationTokenInfo createExpiredCertificationToken(String appName, Set<String> apiPermission) {
+        return JwtTokenProvider.createCertificationToken(appName, apiPermission, -10);
     }
 }

--- a/src/test/java/com/eventty/eventtynextgen/certification/CertificationServiceImplTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/certification/CertificationServiceImplTest.java
@@ -9,12 +9,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.eventty.eventtynextgen.certification.component.CertificationManager;
-import com.eventty.eventtynextgen.config.properties.CertificationApiProperties.Permission;
 import com.eventty.eventtynextgen.shared.exception.CustomException;
 import com.eventty.eventtynextgen.shared.exception.enums.CertificationErrorType;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collections;
-import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -40,7 +39,7 @@ class CertificationServiceImplTest {
             String appName = "client";
             String appSecret = "secretKey";
             HttpServletResponse response = mock(HttpServletResponse.class);
-            Map<String, Permission> apiPermissions = Map.of("user", Permission.OPTIONAL);
+            Set<String> apiPermissions = Set.of("user");
 
             when(certificationManager.hasAppName(appName)).thenReturn(true);
             when(certificationManager.matchesSecretKey(appName, appSecret)).thenReturn(true);
@@ -62,7 +61,7 @@ class CertificationServiceImplTest {
             String appName = "client";
             String appSecret = "secretKey";
             HttpServletResponse response = mock(HttpServletResponse.class);
-            Map<String, Permission> apiPermissions = Collections.emptyMap();
+            Set<String> apiPermissions = Collections.emptySet();
 
             when(certificationManager.hasAppName(appName)).thenReturn(true);
             when(certificationManager.matchesSecretKey(appName, appSecret)).thenReturn(true);


### PR DESCRIPTION
## :bell: Related issues <!-- Please write #[issue_number] -->

#82

## :pencil: Changes and Reasons <!-- Please list what you have changed and why. -->

- API 호출 세부 권한은 삭제하고 API 호출 권한만 확인하도록 변경
- Properties 설정값을 Map을 통하여 관리하던 방식에서 Set 기반의 관리로 변경
- 프로덕션 코드 및 테스트 코드 수정

## :sparkles: PR Point <!-- what you want reviewers to focus on -->

N/A

## :gift: Notes

N/A
