### PR TITLE
[#94] 통합 테스트의 환경을 Embedded MariaDB 방식에서 MySQL 테스트 컨테이너 방식으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
 	id 'org.springframework.boot' version '3.4.3'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'jacoco'
-	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 configurations {
@@ -74,32 +73,26 @@ dependencies {
 	testRuntimeOnly ('org.junit.platform:junit-platform-launcher')
 
 	// test containers
-	testImplementation "org.testcontainers:testcontainers:1.16.0"
-	testImplementation "org.testcontainers:junit-jupiter:1.16.0"
-	testImplementation "org.testcontainers:mysql:1.16.0"
-}
-
-ext {
-	snippetsDir = file('build/generated-snippets')
+	testImplementation("org.springframework.boot:spring-boot-testcontainers")
+	testImplementation("org.testcontainers:junit-jupiter")
+	testImplementation("org.testcontainers:mysql")
 }
 
 test {
 	useJUnitPlatform()
 	finalizedBy('jacocoTestReport')
-	outputs.dir snippetsDir
 }
 
 jacoco {
 	toolVersion = "0.8.13"
-	reportsDirectory = layout.buildDirectory.dir('build/generated-snippets')
 }
 
 jacocoTestReport {
+	dependsOn(test)
 	reports {
-		xml.required.set(true)
 		csv.required.set(false)
+		xml.required.set(true)
 		html.required.set(true)
-		html.outputLocation = layout.buildDirectory.dir('build/generated-snippets/html')
 	}
 	finalizedBy('jacocoTestCoverageVerification')
 }
@@ -114,11 +107,4 @@ jacocoTestCoverageVerification {
 			}
 		}
 	}
-}
-
-asciidoctor {
-	configurations 'asciidoctorExt'
-	baseDirFollowsSourceFile()
-	inputs.dir snippetsDir
-	dependsOn test
 }

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ jacocoTestCoverageVerification {
 			limit {
 				counter = 'LINE'
 				value = 'COVEREDRATIO'
-				minimum = 0.80
+				minimum = 0.70
 			}
 		}
 	}

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/lombok.config
+++ b/lombok.config
@@ -1,1 +1,0 @@
-lombok.addLombokGeneratedAnnotation = true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -6,7 +6,7 @@ spring:
   # Docker 컨테이너로 MySQL, Redis 서버 구동
   docker:
     compose:
-      enabled: true
+      enabled: false
 
   jpa:
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,3 @@ spring:
       client-type: lettuce
       port: 6379
       host: 127.0.0.1
-
-
-
-

--- a/src/test/java/com/eventty/eventtynextgen/EventtyNextgenApplicationTests.java
+++ b/src/test/java/com/eventty/eventtynextgen/EventtyNextgenApplicationTests.java
@@ -1,8 +1,12 @@
 package com.eventty.eventtynextgen;
 
+import com.eventty.eventtynextgen.config.TestcontainersConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
+@Import(TestcontainersConfiguration.class)
 @SpringBootTest
 class EventtyNextgenApplicationTests {
 

--- a/src/test/java/com/eventty/eventtynextgen/auth/AuthControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/auth/AuthControllerTest.java
@@ -23,6 +23,7 @@ import com.eventty.eventtynextgen.base.fixture.CertificationTokenFixture;
 import com.eventty.eventtynextgen.base.fixture.SessionTokenFixture;
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.CertificationTokenInfo;
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.SessionTokenInfo;
+import com.eventty.eventtynextgen.config.TestcontainersConfiguration;
 import com.eventty.eventtynextgen.user.entity.User;
 import com.eventty.eventtynextgen.user.entity.User.UserStatus;
 import com.eventty.eventtynextgen.user.fixture.UserFixture;
@@ -35,11 +36,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -47,10 +47,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@SpringBootTest
 @ActiveProfiles("test")
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@TestInstance(Lifecycle.PER_CLASS)
 @DisplayName("Auth Controller 통합 테스트")
 class AuthControllerTest {
 

--- a/src/test/java/com/eventty/eventtynextgen/auth/AuthControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/auth/AuthControllerTest.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -68,7 +69,7 @@ class AuthControllerTest {
     @Autowired
     private RefreshTokenRepository refreshTokenRepository;
 
-    @AfterEach
+    @BeforeEach
     void tearDown() {
         userRepository.deleteAllInBatch();
     }
@@ -243,7 +244,7 @@ class AuthControllerTest {
 
         private static final String URL = BASE_URL + "/reissue/session-token";
 
-        @AfterEach
+        @BeforeEach
         void tearDown() {
             refreshTokenRepository.deleteAllInBatch();
             userRepository.deleteAllInBatch();

--- a/src/test/java/com/eventty/eventtynextgen/auth/authcode/AuthCodeControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/auth/authcode/AuthCodeControllerTest.java
@@ -17,6 +17,7 @@ import com.eventty.eventtynextgen.auth.authcode.response.AuthCodeSendCodeRespons
 import com.eventty.eventtynextgen.auth.authcode.response.AuthCodeValidateCodeResponseView;
 import com.eventty.eventtynextgen.base.fixture.CertificationTokenFixture;
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.CertificationTokenInfo;
+import com.eventty.eventtynextgen.config.TestcontainersConfiguration;
 import com.eventty.eventtynextgen.user.entity.User;
 import com.eventty.eventtynextgen.user.fixture.UserFixture;
 import com.eventty.eventtynextgen.user.repository.UserRepository;
@@ -25,19 +26,18 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@SpringBootTest
 @ActiveProfiles("test")
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@TestInstance(Lifecycle.PER_CLASS)
 @DisplayName("Auth Code Controller 통합 테스트")
 class AuthCodeControllerTest {
 

--- a/src/test/java/com/eventty/eventtynextgen/auth/authcode/AuthCodeControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/auth/authcode/AuthCodeControllerTest.java
@@ -23,6 +23,7 @@ import com.eventty.eventtynextgen.user.fixture.UserFixture;
 import com.eventty.eventtynextgen.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -55,12 +56,11 @@ class AuthCodeControllerTest {
     @Autowired
     private AuthCodeRepository authCodeRepository;
 
-    @AfterEach
+    @BeforeEach
     void tearDown() {
         authCodeRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
     }
-
 
     @Nested
     @DisplayName("이메일 사용 가능 여부 검사 테스트")

--- a/src/test/java/com/eventty/eventtynextgen/base/filter/ApiPermissionVerifiedFilterTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/filter/ApiPermissionVerifiedFilterTest.java
@@ -37,7 +37,7 @@ class ApiPermissionVerifiedFilterTest {
     @Mock
     private ResponseUtils responseUtils;
 
-    @AfterEach
+    @BeforeEach
     void tearDown() {
         CertificationContextHolder.clearContext();
         SessionContextHolder.clearContext();

--- a/src/test/java/com/eventty/eventtynextgen/base/filter/ApiPermissionVerifiedFilterTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/filter/ApiPermissionVerifiedFilterTest.java
@@ -19,6 +19,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,8 +37,8 @@ class ApiPermissionVerifiedFilterTest {
     @Mock
     private ResponseUtils responseUtils;
 
-    @BeforeEach
-    void setup() {
+    @AfterEach
+    void tearDown() {
         CertificationContextHolder.clearContext();
         SessionContextHolder.clearContext();
     }

--- a/src/test/java/com/eventty/eventtynextgen/base/filter/CertificationTokenFilterTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/filter/CertificationTokenFilterTest.java
@@ -11,12 +11,14 @@ import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.CertificationTo
 import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.VerifyTokenResult;
 import com.eventty.eventtynextgen.shared.context.CertificationContext;
 import com.eventty.eventtynextgen.shared.context.CertificationContextHolder;
+import com.eventty.eventtynextgen.shared.context.SessionContextHolder;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +27,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Certification Token Filter 단위 테스트")
 class CertificationTokenFilterTest {
+
+    @BeforeEach
+    void tearDown() {
+        CertificationContextHolder.clearContext();
+        SessionContextHolder.clearContext();
+    }
 
     @Test
     @DisplayName("유효한 Certification Token과 함께 요청이 들어올 경우, filterChain.doFilter() 직전에 Context에 페이로드 정보가 저장된다")

--- a/src/test/java/com/eventty/eventtynextgen/base/fixture/CertificationTokenFixture.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/fixture/CertificationTokenFixture.java
@@ -7,7 +7,7 @@ import java.util.Set;
 public class CertificationTokenFixture {
 
     public static CertificationTokenInfo createFullAuthorizedCertificationToken() {
-        return createCertificationToken("client1", Set.of("user", "events", "auth_code", "auth_login", "auth    "));
+        return createCertificationToken("client1", Set.of("user", "events", "auth_code", "auth_login", "auth"));
     }
 
     public static CertificationTokenInfo createCertificationToken(String appName, Set<String> apiPermission) {

--- a/src/test/java/com/eventty/eventtynextgen/certification/CertificationControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/certification/CertificationControllerTest.java
@@ -10,26 +10,26 @@ import com.eventty.eventtynextgen.base.exception.CustomException;
 import com.eventty.eventtynextgen.base.exception.ErrorResponse;
 import com.eventty.eventtynextgen.base.exception.enums.CertificationErrorType;
 import com.eventty.eventtynextgen.base.exception.factory.ErrorResponseEntityFactory;
+import com.eventty.eventtynextgen.config.TestcontainersConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@SpringBootTest
 @ActiveProfiles("test")
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@TestInstance(Lifecycle.PER_CLASS)
 @DisplayName("Certification Controller 통합 테스트")
 class CertificationControllerTest {
 

--- a/src/test/java/com/eventty/eventtynextgen/config/TestcontainersConfiguration.java
+++ b/src/test/java/com/eventty/eventtynextgen/config/TestcontainersConfiguration.java
@@ -1,0 +1,15 @@
+package com.eventty.eventtynextgen.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestcontainersConfiguration {
+
+    @Bean
+    @ServiceConnection(name = "mysql")
+    MySQLContainer<?> mysqlContainer() { return new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));}
+}

--- a/src/test/java/com/eventty/eventtynextgen/config/TestcontainersConfiguration.java
+++ b/src/test/java/com/eventty/eventtynextgen/config/TestcontainersConfiguration.java
@@ -11,5 +11,7 @@ public class TestcontainersConfiguration {
 
     @Bean
     @ServiceConnection(name = "mysql")
-    MySQLContainer<?> mysqlContainer() { return new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));}
+    MySQLContainer<?> mysqlContainer() {
+        return new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
+    }
 }

--- a/src/test/java/com/eventty/eventtynextgen/user/UserControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/user/UserControllerTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -72,7 +73,7 @@ public class UserControllerTest {
     @Autowired
     private UserRepository userRepository;
 
-    @AfterEach
+    @BeforeEach
     void tearDown() {
         userRepository.deleteAll();
     }

--- a/src/test/java/com/eventty/eventtynextgen/user/UserControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/user/UserControllerTest.java
@@ -1,7 +1,7 @@
 package com.eventty.eventtynextgen.user;
 
-import static com.eventty.eventtynextgen.base.constant.BaseConst.*;
-import static com.eventty.eventtynextgen.certification.constant.CertificationConst.*;
+import static com.eventty.eventtynextgen.base.constant.BaseConst.AUTHORIZATION_HEADER;
+import static com.eventty.eventtynextgen.certification.constant.CertificationConst.CERTIFICATION_TOKEN_COOKIE_NAME;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -10,9 +10,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.eventty.eventtynextgen.base.fixture.CertificationTokenFixture;
-import com.eventty.eventtynextgen.base.fixture.SessionTokenFixture;
-import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.CertificationTokenInfo;
 import com.eventty.eventtynextgen.base.exception.CustomException;
 import com.eventty.eventtynextgen.base.exception.ErrorResponse;
 import com.eventty.eventtynextgen.base.exception.enums.AuthErrorType;
@@ -20,6 +17,10 @@ import com.eventty.eventtynextgen.base.exception.enums.CommonErrorType;
 import com.eventty.eventtynextgen.base.exception.enums.UserErrorType;
 import com.eventty.eventtynextgen.base.exception.factory.ErrorMsgFactory;
 import com.eventty.eventtynextgen.base.exception.factory.ErrorResponseEntityFactory;
+import com.eventty.eventtynextgen.base.fixture.CertificationTokenFixture;
+import com.eventty.eventtynextgen.base.fixture.SessionTokenFixture;
+import com.eventty.eventtynextgen.base.provider.JwtTokenProvider.CertificationTokenInfo;
+import com.eventty.eventtynextgen.config.TestcontainersConfiguration;
 import com.eventty.eventtynextgen.user.entity.User;
 import com.eventty.eventtynextgen.user.entity.User.UserStatus;
 import com.eventty.eventtynextgen.user.fixture.SignupRequestFixture;
@@ -39,14 +40,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -54,10 +54,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@SpringBootTest
 @ActiveProfiles("test")
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@TestInstance(Lifecycle.PER_CLASS)
 @DisplayName("User Controller 통합 테스트")
 public class UserControllerTest {
 
@@ -471,7 +471,6 @@ public class UserControllerTest {
             User user = UserFixture.createUser();
             User userFromDb = userRepository.save(user);
             String accessTokenHeaderValue = SessionTokenFixture.createAccessTokenHeaderValue(userFromDb.getId());
-
 
             // when
             ResultActions resultActions = mockMvc.perform(delete(BASE_URL)


### PR DESCRIPTION
## :bell: Related issues <!-- Please write #[issue_number] -->

#94

## :pencil: Changes and Reasons <!-- Please list what you have changed and why. -->

- Embedded MariaDB 기반의 통합 테스트에서 TestContainers DB 기반의 통합 테스트로 변경
- jacoco 기본 세팅
- 테스트 커버러지 최소 수치 하향: 80% -> 70%
  -  추후 테스트 커버리지 향상을 위한 작업 수행 예정
- `@AfterEach`에서 수행하던 영속화 데이터 비워주는 작업을 `@BeforeEach`에서 수행
  - 테스트 도중 예기치 못한 상황으로 실패하여 종료되어 `@AfterEach`가 실행되지 못했을 경우 다음 테스트의 결과에 영향을 줄 수 있다.

## :sparkles: PR Point <!-- what you want reviewers to focus on -->

N/A

## :gift: Notes

N/A
