### PR TITLE
[#130] 배포 환경에서 서버의 actuator가 DOWN 상태인 문제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	implementation("com.mysql:mysql-connector-j")
 
 	// redis
-	implementation('org.springframework.boot:spring-boot-starter-data-redis')
+//	implementation('org.springframework.boot:spring-boot-starter-data-redis')
 
 	// lombok
 	compileOnly ('org.projectlombok:lombok')

--- a/src/main/java/com/eventty/eventtynextgen/base/enums/ApiName.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/enums/ApiName.java
@@ -7,16 +7,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ApiName {
 
-    USER("/api/v1/user"),
-    EVENTS("/api/v1/events"),
+    USER("/api/v1/user/**"),
+    EVENTS("/api/v1/events/**"),
 
     // AUTH
-    AUTH_CODE("/api/v1/auth/code"),
-    AUTH_LOGIN("/api/v1/auth/login"),
-    AUTH("/api/v1/auth"),
+    AUTH_CODE("/api/v1/auth/code/**"),
+    AUTH_LOGIN("/api/v1/auth/login/**"),
+    AUTH("/api/v1/auth/**"),
 
     // ASSET
-    ASSET_FILE("/api/v1/asset/file")
+    ASSET_FILE("/api/v1/asset/file/**")
     ;
 
     private final String pattern;

--- a/src/main/java/com/eventty/eventtynextgen/base/exception/enums/CertificationErrorType.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/exception/enums/CertificationErrorType.java
@@ -11,6 +11,7 @@ public enum CertificationErrorType implements ErrorType {
     MISMATCH_SECRET_KEY("MISMATCH_SECRET_KEY", "API 토큰 인증키가 일치하지 않습니다."),
     FAILED_PARSING_CERTIFICATION_TOKEN("FAILED_PARSING_CERTIFICATION_TOKEN", "CERTIFICATION TOKEN을 파싱하는데 실패했습니다."),
     MISMATCH_API_NAME("MISMATCH_API_NAME", "요청 URL에 매칭되는 API NAME을 찾을 수 없습니다"),
+    ACCESS_DENIED("ACCESS_DENIED", "접근이 허용되지 않습니다."),
     NO_API_CALL_PERMISSION_IN_TOKEN("NO_API_CALL_PERMISSION_IN_TOKEN", "요청하신 API 호출 권한이 Token에 담겨있지 않습니다."),
     NO_API_CALL_PERMISSION_IN_YAML("NO_API_CALL_PERMISSION_IN_YAML", "요청하신 API에 대한 호출 권한이 없습니다."),
     ;

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/ApiPermissionVerifiedFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/ApiPermissionVerifiedFilter.java
@@ -3,6 +3,7 @@ package com.eventty.eventtynextgen.base.filter;
 import com.eventty.eventtynextgen.base.enums.ApiName;
 import com.eventty.eventtynextgen.base.utils.ResponseUtils;
 import com.eventty.eventtynextgen.certification.component.CertificationManager;
+import com.eventty.eventtynextgen.shared.constant.SharedConst;
 import com.eventty.eventtynextgen.shared.context.CertificationContext;
 import com.eventty.eventtynextgen.shared.context.CertificationContextHolder;
 import com.eventty.eventtynextgen.base.exception.CustomException;
@@ -23,7 +24,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-// TODO: 예외 발생 시 Details에 RequestURI 정보 추가하고 필요시 ApiName 등 예외 로깅을 위한 정보를 추가
+
 @Slf4j
 @Order(-2)
 @RequiredArgsConstructor
@@ -84,10 +85,9 @@ public class ApiPermissionVerifiedFilter extends OncePerRequestFilter {
         return StringUtils.hasText(context.getAppName()) && Objects.nonNull(context.getApiPermission());
     }
 
-    // TODO: api/v1/events로 요청이 들어오고 ApiName이 api/v1/event로 되어 있는 경우에도 패턴 매칭이 된다. -> Test 케이스 추가 후 수정
     private ApiName resolveApiName(String requestURI, HttpServletResponse response) {
         Optional<ApiName> apiNameOpt = Arrays.stream(ApiName.values())
-            .filter(apiName -> requestURI.startsWith(apiName.getPattern()))
+            .filter(apiName -> SharedConst.PATH_MATCHER.match(apiName.getPattern(), requestURI))
             .findAny();
 
         if (apiNameOpt.isEmpty()) {
@@ -127,6 +127,7 @@ public class ApiPermissionVerifiedFilter extends OncePerRequestFilter {
     }
 
     private void writeErrorResponse(CustomException customException, HttpServletResponse response) {
+        // TODO: LoggerUtils
         log.error("http-status={} code={} msg={} detail={}",
             customException.getHttpStatus().value(),
             customException.getErrorType().getCode(),

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/CertificationTokenFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/CertificationTokenFilter.java
@@ -28,20 +28,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class CertificationTokenFilter extends OncePerRequestFilter {
 
     private static final List<String> SKIP_PATTERNS = List.of(
-        // API 문서
-        "/swagger-ui/**", "/v3/api-docs/**",
-        // 모니터링 및 헬스체크
-        "/health/**", "/actuator/**",
         // 인증 관련
-        "/api/*/certification/**",
-        // 정적 리소스
-        "/css/**", "/js/**", "/images/**", "/webjars/**", "/fonts/**", "/resources/**", "/static/**",
-        // 오류 페이지
-        "/error/**",
-        // 크롬 개발자 도구 자동 요청이나 인증 경로
-        "/.well-known/**",
-        // 기타 리소스
-        "/favicon.ico", "/robots.txt"
+        "/api/*/certification/**"
     );
 
     @Override
@@ -70,6 +58,11 @@ public class CertificationTokenFilter extends OncePerRequestFilter {
     }
 
     private boolean shouldSkip(String uri) {
+        // "/api"로 시작하지 않는 URI는 모두 스킵 대상
+        if (!uri.startsWith("/api")) {
+            return true;
+        }
+
         return SKIP_PATTERNS.stream()
             .anyMatch(pattern -> PATH_MATCHER.match(pattern, uri));
     }

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/NonApiAllowListFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/NonApiAllowListFilter.java
@@ -55,7 +55,7 @@ public class NonApiAllowListFilter extends OncePerRequestFilter {
         }
 
         // 2. 예외 URL이 아닐 경우 404 응답
-        CustomException customException = CustomException.of(HttpStatus.FORBIDDEN, CertificationErrorType.NO_API_CALL_PERMISSION_IN_TOKEN, "URI: " + uri);
+        CustomException customException = CustomException.of(HttpStatus.FORBIDDEN, CertificationErrorType.ACCESS_DENIED, "URI: " + uri);
         writeErrorResponse(customException, response);
     }
 

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/NonApiAllowListFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/NonApiAllowListFilter.java
@@ -1,0 +1,72 @@
+package com.eventty.eventtynextgen.base.filter;
+
+import static com.eventty.eventtynextgen.shared.constant.SharedConst.PATH_MATCHER;
+
+import com.eventty.eventtynextgen.base.exception.CustomException;
+import com.eventty.eventtynextgen.base.exception.enums.CertificationErrorType;
+import com.eventty.eventtynextgen.base.utils.ResponseUtils;
+import com.eventty.eventtynextgen.shared.utils.LoggerUtils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Order(-4)
+@RequiredArgsConstructor
+@Component
+public class NonApiAllowListFilter extends OncePerRequestFilter {
+
+    private final ResponseUtils responseUtils;
+
+    private static final List<String> SKIP_PATTERNS = List.of(
+        // API
+        "/api/**",
+        // API 문서
+        "/swagger-ui/**", "/v3/api-docs/**",
+        // 모니터링 및 헬스체크
+        "/health/**", "/actuator/**",
+        // 정적 리소스
+        "/css/**", "/js/**", "/images/**", "/webjars/**", "/fonts/**", "/resources/**", "/static/**",
+        // 오류 페이지
+        "/error/**",
+        // 크롬 개발자 도구 자동 요청이나 인증 경로
+        "/.well-known/**",
+        // 기타 리소스
+        "/favicon.ico", "/robots.txt"
+    );
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // 1. 예외 URL에 해당하는지 확인
+        String uri = request.getRequestURI();
+
+        if (shouldSkip(uri)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 2. 예외 URL이 아닐 경우 404 응답
+        CustomException customException = CustomException.of(HttpStatus.FORBIDDEN, CertificationErrorType.NO_API_CALL_PERMISSION_IN_TOKEN, "URI: " + uri);
+        writeErrorResponse(customException, response);
+    }
+
+    private boolean shouldSkip(String uri) {
+        return SKIP_PATTERNS.stream()
+            .anyMatch(pattern -> PATH_MATCHER.match(pattern, uri));
+    }
+
+    private void writeErrorResponse(CustomException customException, HttpServletResponse response) {
+        LoggerUtils.debug(customException);
+
+        responseUtils.writeErrorResponseToResponse(response, customException);
+    }
+}

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/SessionCheckFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/SessionCheckFilter.java
@@ -18,6 +18,7 @@ import com.eventty.eventtynextgen.shared.context.SessionContextHolder;
 import com.eventty.eventtynextgen.base.exception.CustomException;
 import com.eventty.eventtynextgen.base.exception.enums.AuthErrorType;
 import com.eventty.eventtynextgen.base.exception.enums.UserErrorType;
+import com.eventty.eventtynextgen.shared.utils.LoggerUtils;
 import com.eventty.eventtynextgen.user.entity.User;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -113,6 +114,7 @@ public class SessionCheckFilter extends OncePerRequestFilter {
                     customException = CustomException.of(HttpStatus.INTERNAL_SERVER_ERROR, AuthErrorType.UNKNOWN_EXCEPTION);
                 }
             }
+            LoggerUtils.info(customException);
             this.responseUtils.writeErrorResponseToResponse(response, customException);
             return false;
         }
@@ -125,6 +127,7 @@ public class SessionCheckFilter extends OncePerRequestFilter {
 
         if (userOpt.isEmpty()) {
             CustomException customException = CustomException.badRequest(UserErrorType.NOT_FOUND_USER);
+            LoggerUtils.info(customException, "Session Check Filter - 사용자 조회 실패");
             this.responseUtils.writeErrorResponseToResponse(response, customException);
             return null;
         }
@@ -134,6 +137,7 @@ public class SessionCheckFilter extends OncePerRequestFilter {
     private boolean validateUser(User user, HttpServletResponse response) {
         if (user.isDeleted()) {
             CustomException customException = CustomException.badRequest(UserErrorType.USER_ALREADY_DELETED);
+            LoggerUtils.info(customException, "Session Check Filter - 삭제된 사용자");
             this.responseUtils.writeErrorResponseToResponse(response, customException);
             return false;
         }

--- a/src/main/java/com/eventty/eventtynextgen/config/RedisConfig.java
+++ b/src/main/java/com/eventty/eventtynextgen/config/RedisConfig.java
@@ -2,14 +2,11 @@ package com.eventty.eventtynextgen.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-@Configuration
+//@Configuration
 public class RedisConfig {
 
-    @Bean
+/*    @Bean
     public RedisTemplate<String, Object> redisTemplate(
         RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
@@ -19,6 +16,6 @@ public class RedisConfig {
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
 
         return redisTemplate;
-    }
+    }*/
 
 }

--- a/src/main/java/com/eventty/eventtynextgen/shared/utils/LoggerUtils.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/utils/LoggerUtils.java
@@ -25,7 +25,7 @@ public class LoggerUtils {
     }
 
     public static void info(CustomException customException) {
-        info(customException, customException.getDetail() == null ? "" : customException.getDetail().toString());
+        info(customException, String.valueOf(customException.getDetail()));
     }
 
     public static void info(CustomException customException, String detail) {

--- a/src/main/java/com/eventty/eventtynextgen/shared/utils/LoggerUtils.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/utils/LoggerUtils.java
@@ -1,0 +1,46 @@
+package com.eventty.eventtynextgen.shared.utils;
+
+import com.eventty.eventtynextgen.base.exception.CustomException;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UtilityClass
+public class LoggerUtils {
+
+    public static void error(CustomException customException) {
+        log.error("http-status={} code={} msg={} detail={}",
+            customException.getHttpStatus().value(),
+            customException.getErrorType().getCode(),
+            customException.getErrorType().getMsg(),
+            customException.getDetail());
+    }
+
+    public static void debug(CustomException customException) {
+        log.debug("http-status={} code={} msg={} detail={}",
+            customException.getHttpStatus().value(),
+            customException.getErrorType().getCode(),
+            customException.getErrorType().getMsg(),
+            customException.getDetail());
+    }
+
+    public static void info(CustomException customException) {
+        info(customException, customException.getDetail() == null ? "" : customException.getDetail().toString());
+    }
+
+    public static void info(CustomException customException, String detail) {
+        log.info("http-status={} code={} msg={} detail={}",
+            customException.getHttpStatus().value(),
+            customException.getErrorType().getCode(),
+            customException.getErrorType().getMsg(),
+            detail);
+    }
+
+    public static void warn(CustomException customException) {
+        log.warn("http-status={} code={} msg={} detail={}",
+            customException.getHttpStatus().value(),
+            customException.getErrorType().getCode(),
+            customException.getErrorType().getMsg(),
+            customException.getDetail());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,11 +13,11 @@ spring:
       test:
         - certification-test
         - certification-secret-test
-  data:
-    redis:
-      client-type: lettuce
-      port: 6379
-      host: 127.0.0.1
+#  data:
+#    redis:
+#      client-type: lettuce
+#      port: 6379
+#      host: 127.0.0.1
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.xml
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,18 +2,24 @@ spring:
   application:
     name: eventty-nextgen
   profiles:
-    default: local, properties, metrics
+    default: local
     group:
       dev:
+        - metrics
+        - properties
         - certification
         - certification-secret
       local:
+        - metrics
+        - properties
         - certification
         - certification-secret
       test:
+        - metrics
+        - properties
         - certification-test
         - certification-secret-test
-#  data:
+  #  data:
 #    redis:
 #      client-type: lettuce
 #      port: 6379

--- a/src/test/java/com/eventty/eventtynextgen/base/filter/ApiPermissionVerifiedFilterTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/filter/ApiPermissionVerifiedFilterTest.java
@@ -19,11 +19,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -106,9 +110,10 @@ class ApiPermissionVerifiedFilterTest {
         verify(filterChain, times(0)).doFilter(request, response);
     }
 
-    @Test
+    @ParameterizedTest(name = "[{index}] URI: {0}")
+    @MethodSource("mismatchUriPatternArguments")
     @DisplayName("요청의 Path로부터 API Name을 찾지 못했을 경우 요청은 필터링된다.")
-    void 요청의_Path로부터_API_Name을_찾지_못했을_경우_요청은_필터링된다() throws ServletException, IOException {
+    void 요청의_Path로부터_API_Name을_찾지_못했을_경우_요청은_필터링된다(String fixtureName, String requestURI) throws ServletException, IOException {
         // given
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
@@ -117,7 +122,7 @@ class ApiPermissionVerifiedFilterTest {
         CertificationContext context = CertificationContextHolder.getContext();
         context.updateFromTokenClaims("client", Set.of("user"), "adminEmail@gmail.com");
 
-        when(request.getRequestURI()).thenReturn("/nothing-match-url");
+        when(request.getRequestURI()).thenReturn(requestURI);
         doNothing().when(responseUtils).writeErrorResponseToResponse(any(HttpServletResponse.class), any(CustomException.class));
 
         ApiPermissionVerifiedFilter apiPermissionVerifiedFilter = new ApiPermissionVerifiedFilter(certificationManager, responseUtils);
@@ -127,6 +132,47 @@ class ApiPermissionVerifiedFilterTest {
 
         // then
         verify(filterChain, times(0)).doFilter(request, response);
+    }
+
+    private static Stream<Arguments> mismatchUriPatternArguments() {
+        return Stream.of(
+            // 완전히 다른 패턴
+            Arguments.of("완전히 다른 패턴", "/api/v2/user"),
+            Arguments.of("완전히 다른 패턴", "/different/path"),
+
+            // 추가 경로가 있지만 패턴에 맞지 않는 경우
+            Arguments.of("패턴 뒤에 슬래시가 아닌 문자열이 온 경우", "/api/v1/userses"),
+            Arguments.of("패턴 뒤에 슬래시가 아닌 문자열이 온 경우", "/api/v1/auths"),
+
+            // API 버전이 다른 경우
+            Arguments.of("API 버전 불일치", "/api/v2/events"),
+            Arguments.of("API 버전 불일치", "/api/v0/auth"),
+
+            // 오타가 있는 경우
+            Arguments.of("오타", "/api/v1/usr"),
+            Arguments.of("오타", "/api/v1/event"), // events의 단수형
+            Arguments.of("오타", "/api/v1/eventss"), // 이중 's'
+            Arguments.of("오타", "/api/v1/asset/files"), // file의 복수형
+
+            // 패스 구조가 다른 경우
+            Arguments.of("패스 구조 불일치", "/user/api/v1"),
+            Arguments.of("패스 구조 불일치", "/v1/api/user"),
+            Arguments.of("패스 구조 불일치", "/api/user/v1"),
+
+            // 빈 문자열이나 null 케이스
+            Arguments.of("빈 문자열", ""),
+            Arguments.of("루트 패스", "/"),
+
+            // 대소문자 다른 경우
+            Arguments.of("대소문자 불일치", "/API/V1/USER"),
+            Arguments.of("대소문자 불일치", "/api/V1/events"),
+            Arguments.of("대소문자 불일치", "/Api/v1/auth"),
+
+            // 슬래시 누락 케이스
+            Arguments.of("슬래시 누락", "api/v1/user"),
+            Arguments.of("슬래시 누락", "/apiv1/user"),
+            Arguments.of("슬래시 누락", "/api/v1user")
+        );
     }
 
     @Test

--- a/src/test/java/com/eventty/eventtynextgen/base/filter/NonApiAllowListFilterTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/filter/NonApiAllowListFilterTest.java
@@ -1,0 +1,117 @@
+package com.eventty.eventtynextgen.base.filter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eventty.eventtynextgen.base.exception.CustomException;
+import com.eventty.eventtynextgen.base.utils.ResponseUtils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("제어권이 없는 API 요청 필터 단위 테스트")
+class NonApiAllowListFilterTest {
+
+    @Mock
+    private ResponseUtils responseUtils;
+
+    @ParameterizedTest(name = "[{index}] URI: {0}")
+    @MethodSource("skipPatternArguments")
+    @DisplayName("예외 URL 패턴이 올바르게 적용되는지 확인 테스트")
+    void 예외_URL_패턴이_올바르게_적용되는지_확인_테스트(String fixtureName, String requestURI) throws ServletException, IOException {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+
+        when(request.getRequestURI()).thenReturn(requestURI);
+
+        NonApiAllowListFilter nonApiAllowListFilter = new NonApiAllowListFilter(responseUtils);
+
+        // when
+        nonApiAllowListFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(filterChain, times(1)).doFilter(request, response);
+        verify(responseUtils, times(0)).writeErrorResponseToResponse(any(HttpServletResponse.class), any(CustomException.class));
+    }
+
+    @Test
+    @DisplayName("예외 URL 패턴이 아닌 경우 요청은 필터링되어 예외 데이터와 같이 응답된다")
+    void 예외_URL_패턴이_아닌_경우_요청은_필터링되어_예외_데이터와_같이_응답된다() throws ServletException, IOException {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+
+        String requestURI = "/attack";
+
+        when(request.getRequestURI()).thenReturn(requestURI);
+        doNothing().when(responseUtils).writeErrorResponseToResponse(any(HttpServletResponse.class), any(CustomException.class));
+
+        NonApiAllowListFilter nonApiAllowListFilter = new NonApiAllowListFilter(responseUtils);
+
+        // when
+        nonApiAllowListFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(filterChain, times(0)).doFilter(request, response);
+        verify(responseUtils, times(1)).writeErrorResponseToResponse(any(HttpServletResponse.class), any(CustomException.class));
+    }
+
+
+    private static Stream<Arguments> skipPatternArguments() {
+        return Stream.of(
+            Arguments.of("/api/**",
+                "/api/v1/users"),
+            Arguments.of("/swagger-ui/**",
+                "/swagger-ui/index.html"),
+            Arguments.of("/v3/api-docs/**",
+                "/v3/api-docs/swagger-config"),
+            Arguments.of("/health/**",
+                "/health/check"),
+            Arguments.of("/health",
+                "/health"),
+            Arguments.of("/actuator/**",
+                "/actuator/health"),
+            Arguments.of("/css/**",
+                "/css/main.css"),
+            Arguments.of("/js/**",
+                "/js/app.js"),
+            Arguments.of("/images/**",
+                "/images/logo.png"),
+            Arguments.of("/webjars/**",
+                "/webjars/bootstrap/5.1.3/css/bootstrap.min.css"),
+            Arguments.of("/fonts/**",
+                "/fonts/roboto.woff2"),
+            Arguments.of("/resources/**",
+                "/resources/application.properties"),
+            Arguments.of("/static/**",
+                "/static/index.html"),
+            Arguments.of("/error/**",
+                "/error/404"),
+            Arguments.of("/.well-known/**",
+                "/.well-known/security.txt"),
+            Arguments.of("/favicon.ico",
+                "/favicon.ico"),
+            Arguments.of("/robots.txt",
+                "/robots.txt")
+        );
+    }
+}


### PR DESCRIPTION
## :bell: Related issues <!-- Please write #[issue_number] -->

#130

## :pencil: Changes and Reasons <!-- Please list what you have changed and why. -->

### Nginx 엣지 필터링 추가

**why:** 크롤러/스캐너/공격성 요청이 애플리케이션까지 들어오면 불필요한 리소스 낭비와 로그 노이즈가 발생합니다.

**change:** 배포 파이프라인에 Nginx 차단 규칙을 추가해 비정상/스캔 패턴을 엣지에서 선차단(444) 하도록 했습니다.

### Redis 의존성 임시 제거

**why:** Spring Actuator는 Health Indicator 중 하나라도 DOWN이면 전체 DOWN으로 집계됩니다. 배포 환경은 Redis 미구성이라 RedisHealthIndicator가 DOWN을 유발했습니다.

**change:** Redis 의존성을 임시 제거(또는 활성 프로필에서 비활성화)하여 Actuator 상태를 UP으로 복구했습니다.

**note:** Redis는 Events 도메인 진행 과정에서 필요시 서버 구성 후 재도입 예정.

### 배포 프로필 적용 오류 수정

**why:** 컨테이너 실행 시 프로필 주입 환경변수 구성이 잘못되어, 공통 설정(application.yml)이 기대대로 머지되지 않았습니다.

**change:** application.yml 및 프로필 구성 방식을 정정하여 특정 profiles일 경우 의도한 설정 파일이 모두 적용되도록 수정했습니다.

### NonAllowListFilter 추가(경계 책임 분리)

**why:** CertificationTokenFilter의 책임은 API 권한 토큰 파싱입니다. “허용되지 않은 경로 차단”까지 맡기면 SRP 위반입니다.

**change:** 허용 리스트(allow-list) 기준으로 /api/** 이외 의도하지 않은 요청을 차단/우회 처리하는 NonAllowListFilter를 앞단에 추가했습니다.

### ApiPermissionVerifiedFilter의 경로 매칭 로직 교체

**why:** String.startsWith() 사용으로 /api/v1/user만 허용 의도였으나, /api/v1/users도 통과하는 오검출이 발생.

**change:** AntPathMatcher 기반으로 패턴 매칭을 수행하게 변경(예: /api/v1/user/**).

**테스트 보강(패턴 회귀 방지)**

**why:** 패턴 매칭에 문제가 있음에도 필터에서 예외가 발생하지 않은 상황이 발생했습니다.

**change:** `@ParameterizedTest`로 다양한 URI 시나리오(허용/차단/에지 케이스)를 데이터 드리븐 검증.

## :sparkles: PR Point <!-- what you want reviewers to focus on -->

N/A

## :gift: Notes

N/A
