### PR TITLE
[#138] 413 Request Entity Too Long 문제 해결

### DIFF
--- a/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileController.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileController.java
@@ -48,8 +48,8 @@ public class AssetFileController {
     }
 
     @LoginRequired(requireHost = true, requireAdmin = true)
-    @PostMapping(value ="/multipart-files")
-    public ResponseEntity<List<AssetUploadAssetFile>> uploadMultipartFiles(@RequestParam("files") List<MultipartFile> files) {
+    @PostMapping(value ="/multipart-files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<AssetUploadAssetFile>> uploadMultipartFiles(@RequestPart("files") List<MultipartFile> files) {
 
         List<AssetUploadAssetFile> assetUploadAssetFiles = this.assetFileService.uploadMultipartFiles(files);
 

--- a/src/main/resources/application-servlet.yml
+++ b/src/main/resources/application-servlet.yml
@@ -1,7 +1,0 @@
-spring:
-  servlet:
-    multipart:
-      max-file-size: 25MB
-      max-request-size: 25MB
-      file-size-threshold: 25MB
-      location: /tmp/uploads

--- a/src/main/resources/application-servlet.yml
+++ b/src/main/resources/application-servlet.yml
@@ -1,0 +1,7 @@
+spring:
+  servlet:
+    multipart:
+      max-file-size: 25MB
+      max-request-size: 25MB
+      file-size-threshold: 25MB
+      location: /tmp/uploads

--- a/src/main/resources/application-tomcat.yml
+++ b/src/main/resources/application-tomcat.yml
@@ -1,0 +1,53 @@
+server:
+  port: 8080
+  servlet:
+    context-path: /
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+  tomcat:
+    # 파일 업로드/요청 크기 제한
+    max-swallow-size: 25MB
+    max-http-form-post-size: 25MB
+
+    # 커넥션 풀 설정
+    threads:
+      max: 200
+      min-spare: 10
+
+    # 커넥션 타임아웃 설정
+    connection-timeout: 20000
+    keep-alive-timeout: 20000
+    max-keep-alive-requests: 100
+
+    # 액세스 로그 설정 (개발환경에서는 false, 운영환경에서는 true)
+    accesslog:
+      enabled: true
+      directory: logs
+      file-date-format: .yyyy-MM-dd
+      pattern: '%t "%r" %s (%D ms) %b %{User-Agent}i'
+      prefix: access_log
+      suffix: .log
+
+    # 추가 설정
+    uri-encoding: UTF-8
+    redirect-context-root: false
+
+# 로깅 설정 (에러 추적을 위한 상세 로깅)
+logging:
+  level:
+    org.apache.catalina: INFO
+    org.apache.coyote: INFO
+    org.apache.tomcat: INFO
+    org.springframework.web: DEBUG
+  pattern:
+    console: '%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n'
+    file: '%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n'
+  file:
+    name: logs/application.log
+  logback:
+    rollingpolicy:
+      max-file-size: 100MB
+      max-history: 30
+      total-size-cap: 3GB

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,25 +5,23 @@ spring:
     default: local
     group:
       dev:
+        - tomcat
         - metrics
         - properties
         - certification
         - certification-secret
       local:
+        - tomcat
         - metrics
         - properties
         - certification
         - certification-secret
       test:
+        - tomcat
         - metrics
         - properties
         - certification-test
         - certification-secret-test
-  #  data:
-#    redis:
-#      client-type: lettuce
-#      port: 6379
-#      host: 127.0.0.1
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.xml
   config:
@@ -33,4 +31,9 @@ spring:
       storage:
         credentials:
           encoded-key: ${GCP_SA_STORAGE_KEY}
-
+  servlet:
+    multipart:
+      max-file-size: 25MB
+      max-request-size: 25MB
+      file-size-threshold: 25MB
+      location: /tmp/uploads


### PR DESCRIPTION
## :bell: Related issues <!-- Please write #[issue_number] -->

#138

## :pencil: Changes and Reasons <!-- Please list what you have changed and why. -->

**413 에러 원인 발생 확인 후 설정 변경**

발생 원인은 다음과 같다.

- tomcat server 설정상 request 의 body 데이터 크기 제한이 2MB로 기본 설정되어 있다.
- spring.servlet.multipart의 `max-file-size`의 기본 크기는 1MB라고 한다.

따라서 이 값들을 25MB로 수정하고, 25MB가 초과 했을 경우 대용량 파일 전송 API를 사용하도록 한다.

**톰캣 설정 추가**

개발 환경에 맞춘 설정의 부재로 인해 톰캣 서버에서 발생한 에러를 확인하기도 불가능한 상황이었다.

따라서 로깅을 강화하고, 기본 설정으로 필요한 값들을 추가했다.

## :sparkles: PR Point <!-- what you want reviewers to focus on -->

N/A

## :gift: Notes

N/A
