### PR TITLE
[#140] Ngrinder 성능 테스트를 위한 서버 설정 변경

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -188,8 +188,8 @@ jobs:
           worker_processes auto;
           pid /run/nginx.pid;
 
-          events { 
-            worker_connections 1024; 
+          events {
+            worker_connections 1024;
           }
 
           http {
@@ -197,17 +197,17 @@ jobs:
             default_type application/octet-stream;
 
             log_format main '$remote_addr - $remote_user [$time_local] "$request" '
-                            '$status $body_bytes_sent "$http_referer" '
-                            '"$http_user_agent" "$http_x_forwarded_for"';
-                            
+                           '$status $body_bytes_sent "$http_referer" '
+                           '"$http_user_agent" "$http_x_forwarded_for"';
+
             access_log /var/log/nginx/access.log main;
             error_log  /var/log/nginx/error.log;
 
-            sendfile on; 
-            tcp_nopush on; 
+            sendfile on;
+            tcp_nopush on;
             keepalive_timeout 65s;
-            
-            client_max_body_size 25M;
+
+            client_max_body_size 10M;
             server_tokens off;
 
             # TLS 최신만
@@ -223,11 +223,14 @@ jobs:
             server {
               listen 80; listen [::]:80;
               server_name ${{ env.DOMAIN }};
-              
+
               location ^~ /.well-known/acme-challenge/ {
                 root /var/www/certbot;
               }
-              return 301 https://$host$request_uri;
+          #   return 301 https://$host$request_uri;    # 실제 운영 환경에서는 redirect하여 https 요청으로 수행하도록 해야한다. (Ngrinder 성능 테스트를 위해 http 요청도 허용)
+              location / {
+                proxy_pass http://api;
+              }
             }
 
             server {
@@ -262,6 +265,8 @@ jobs:
           EOF
           sudo nginx -t
           sudo systemctl reload nginx
+  
+
 
       - name: Stop & remove existing container if present
         shell: bash


### PR DESCRIPTION
## :bell: Related issues <!-- Please write #[issue_number] -->

#140

## :pencil: Changes and Reasons <!-- Please list what you have changed and why. -->

**Nginx 설정 변경**

개발 서버에서 HTTP 요청이 들어올 경우 redirect를 수행하여 HTTPS 요청로 처리하도록 하는 것이 아닌 곧바로 upstream 서버로 전달

구글링한 결과 Ngrinder는 http 요청로 수행하도록 권장하고 있으며, 해당 이슈에서 언급한 문제도 해당 방식으로 해결해보라고 언급하고 있습니다.

http 요청을 허용한 결과 성공적으로 파일 업로드 API를 대상으로 성능 테스트를 수행할 수 있었습니다.

**서버 스펙**
CPU: e2-standard-2 (vCPU 2개)
Memory: 8GB
전단부 서버: Nginx
후단부 서버: API 서버(Docker)

**1차 테스트**
- 하루 ACTIVE 사용자: 100만
- 파일 업로드 API 호출 횟수: 1회
- TPS: 1,000,000 / (24 * 60 * 60) = 11.57 
- 가상 사용자 수: 116 (약 11.57 * 10) (Peak Time)
- 테스트 수행 시간: 5분
- 파일 크기: 4MB
- 총 파일 업로드 크기: 4MB * 115 * 60 * 5 = 139.2GB

> System CPU의 부하로 인해 100% 사용량에 도달. 요청 처리 평균 시간 19ms

<img width="351" height="351" alt="파일 업로드 API 테스트 결과" src="https://github.com/user-attachments/assets/3307a304-67ac-413c-90c4-829df77549fa" />

<img width="1108" height="931" alt="스크린샷 2025-10-16 오후 4 58 46" src="https://github.com/user-attachments/assets/3eb08a6e-4dbf-45dc-b39b-3002b8a062af" />

> Thread 사용량은 평균적으로 100개 정도였지만, CPU의 부하로 인해서 요청 처리 평균 시간이 19ms 정도로 측정되는 것을 확인할 수 있었다.

**2차 테스트**
- 하루 ACTIVE 사용자: 10만
- 파일 업로드 API 호출 횟수: 1회
- TPS: 100,000 / (24 * 60 * 60) = 1.16
- 가상 사용자 수: 12 (약 1.16 * 10) (Peak Time)
- 테스트 수행 시간: 5분
- 파일 크기: 4MB
- 총 파일 업로드 크기: 4MB * 12 * 60 * 5 = 14.4GB

> 요청 처리 평균 시간 3.2ms

<img width="439" height="367" alt="스크린샷 2025-10-16 오후 5 15 34" src="https://github.com/user-attachments/assets/f4117cc1-1966-4363-b644-5df021a6c2ea" />

<img width="1102" height="913" alt="스크린샷 2025-10-16 오후 5 16 14" src="https://github.com/user-attachments/assets/37d365c9-5763-42d1-8793-ddd3af359b7b" />


## :sparkles: PR Point <!-- what you want reviewers to focus on -->

N/A

## :gift: Notes

N/A
