### PR TITLE
[#146] Session Token Check Filter에서 발생한 문제 해결

### DIFF
--- a/src/main/java/com/eventty/eventtynextgen/auth/service/SessionTokenServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/auth/service/SessionTokenServiceImpl.java
@@ -92,7 +92,7 @@ public class SessionTokenServiceImpl implements SessionTokenService {
 
     @Override
     public Long getUserIdFromExpiredAccess(String sessionToken) {
-        AccessTokenPayload accessTokenPayload = JwtTokenProvider.extractAccessTokenPayloadIgnoringExpiration(sessionToken);
+        AccessTokenPayload accessTokenPayload = JwtTokenProvider.extractAccessTokenPayloadIgnoringExpiredExpiration(sessionToken);
 
         return accessTokenPayload.getUserId();
     }

--- a/src/main/java/com/eventty/eventtynextgen/base/aspect/LoginRequiredAspect.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/aspect/LoginRequiredAspect.java
@@ -1,38 +1,109 @@
 package com.eventty.eventtynextgen.base.aspect;
 
 import com.eventty.eventtynextgen.base.annotation.LoginRequired;
+import com.eventty.eventtynextgen.base.exception.enums.ErrorType;
+import com.eventty.eventtynextgen.base.exception.enums.UserErrorType;
+import com.eventty.eventtynextgen.shared.component.user.UserComponent;
+import com.eventty.eventtynextgen.shared.context.SessionContext;
 import com.eventty.eventtynextgen.shared.context.SessionContextHolder;
 import com.eventty.eventtynextgen.base.exception.CustomException;
 import com.eventty.eventtynextgen.base.exception.enums.AuthErrorType;
+import com.eventty.eventtynextgen.shared.provider.JwtTokenProvider.VerifyTokenResult;
+import com.eventty.eventtynextgen.user.entity.User;
 import com.eventty.eventtynextgen.user.entity.enums.UserRoleType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
+import static com.eventty.eventtynextgen.base.exception.enums.AuthErrorType.FAILED_TOKEN_VERIFIED;
+import static com.eventty.eventtynextgen.base.exception.enums.AuthErrorType.ILLEGAL_STATE_JWT_TOKEN;
+import static com.eventty.eventtynextgen.base.exception.enums.AuthErrorType.INVALID_SIGNATURE_JWT_TOKEN;
+import static com.eventty.eventtynextgen.base.exception.enums.AuthErrorType.JWT_TOKEN_EXPIRED;
+import static com.eventty.eventtynextgen.base.exception.enums.AuthErrorType.LOGIN_REQUIRED_API;
+import static com.eventty.eventtynextgen.base.exception.enums.AuthErrorType.UNSUPPORTED_JWT_TOKEN;
+
+@Slf4j
 @Aspect
 @Component
+@RequiredArgsConstructor
 public class LoginRequiredAspect {
+
+    private final UserComponent userComponent;
 
     @Before("@annotation(loginRequired)")
     public void checkAuthority(JoinPoint joinPoint, LoginRequired loginRequired) {
         if (loginRequired.requireLogin()) {
-            if (!SessionContextHolder.getContext().validate()) {
-                throw CustomException.of(HttpStatus.FORBIDDEN, AuthErrorType.LOGIN_REQUIRED_API);
+            // 1. Session Token 파싱에 성공했는지 확인
+            SessionContext context = SessionContextHolder.getContext();
+            if (!context.isSuccessParsingToken()) {
+                VerifyTokenResult verifyTokenResult = context.getVerifyTokenResult();
+                ErrorType errorType = getErrorTypeFromVerifyTokenResult(verifyTokenResult);
+                log.debug("토큰의 검증에 실패했습니다. token value: {}, errorType Code: {}, errorType Msg: {}", context.getSessionToken(), errorType.getCode(), errorType.getMsg());
+                if (errorType == AuthErrorType.UNKNOWN_EXCEPTION) {
+                    throw CustomException.of(HttpStatus.INTERNAL_SERVER_ERROR, AuthErrorType.UNKNOWN_EXCEPTION);
+                } else {
+                    throw CustomException.of(HttpStatus.UNAUTHORIZED, errorType);
+                }
             }
 
-            // API 호출 권한이 필요한 경우
-            if (requiredRole(loginRequired)) {
-                String userRole = SessionContextHolder.getContext().getRole();
-
-                if (!checkAuthority(loginRequired, userRole)) {
-                    // 1개라도 일치하는 권한이 없을 경우
-                    throw CustomException.of(HttpStatus.FORBIDDEN, AuthErrorType.AUTH_USER_NOT_AUTHORIZED);
+            // 2. 사용자 조회
+            User user = userComponent.getUserByUserId(context.getUserId()).orElseThrow(
+                () -> {
+                    log.debug("사용자 조회에 실패했습니다. userId: {}", context.getUserId());
+                    return CustomException.of(HttpStatus.UNAUTHORIZED, UserErrorType.NOT_FOUND_USER);
                 }
+            );
+
+            // 3. 사용자 검증
+            if (user.isDeleted()) {
+                log.debug("삭제된 사용자이므로 검증에 실패했습니다. userId: {}", context.getUserId());
+                throw CustomException.of(HttpStatus.UNAUTHORIZED, UserErrorType.USER_ALREADY_DELETED);
+            }
+
+            // 4. 역할 기반 API 호출 권한 검증
+            String userRole = user.getUserRole().name();
+            if (requiredRole(loginRequired) && !checkAuthority(loginRequired, userRole)) {
+                // 1개라도 일치하는 권한이 없을 경우
+                log.debug("사용자에게 API 호출 권한이 없습니다. requiredRole Admin: {}, Host: {}, User: {}, userRole: {}", loginRequired.requireAdmin(), loginRequired.requireHost(), loginRequired.requireUser(), userRole);
+                throw CustomException.of(HttpStatus.FORBIDDEN, AuthErrorType.AUTH_USER_NOT_AUTHORIZED);
+            }
+
+            // 5. 사용자 역할 정보 업데이트
+            context.updateRole(userRole);
+        }
+    }
+
+    private ErrorType getErrorTypeFromVerifyTokenResult(VerifyTokenResult verifyTokenResult) {
+        if (verifyTokenResult == null) {
+            return LOGIN_REQUIRED_API;
+        }
+
+        switch (verifyTokenResult) {
+            case EXPIRED_TOKEN -> {
+                return JWT_TOKEN_EXPIRED;
+            }
+            case UNSUPPORTED_TOKEN -> {
+                return UNSUPPORTED_JWT_TOKEN;
+            }
+            case ILLEGAL_STATE_TOKEN -> {
+                return ILLEGAL_STATE_JWT_TOKEN;
+            }
+            case INVALID_SIGNATURE_TOKEN -> {
+                return INVALID_SIGNATURE_JWT_TOKEN;
+            }
+            case UNKNOWN_ERROR -> {
+                return FAILED_TOKEN_VERIFIED;
+            }
+            default -> {
+                return AuthErrorType.UNKNOWN_EXCEPTION;
             }
         }
     }
+
     private boolean checkAuthority(LoginRequired loginRequired, String userRole) {
         // ADMIN 권한이 필요한 경우
         UserRoleType userRoleType = UserRoleType.valueOf(userRole);

--- a/src/main/java/com/eventty/eventtynextgen/base/exception/enums/AuthErrorType.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/exception/enums/AuthErrorType.java
@@ -17,7 +17,7 @@ public enum AuthErrorType implements ErrorType {
     AUTH_USER_NOT_ACTIVE("AUTH_USER_NOT_ACTIVE", "해당 유저는 활성화 상태가 아닙니다."),
 
     // JWT
-    FAIL_VERIFY_JWT_TOKEN("FAIL_VERIFY_JWT_TOKEN", "토큰 검증에 실패했습니다"),
+    FAIL_PARSING_JWT_TOKEN("FAIL_PARSING_JWT_TOKEN", "토큰 파싱에 실패했습니다"),
     JWT_TOKEN_EXPIRED("JWT_TOKEN_EXPIRED", "토큰 인증 기간이 지났습니다. 재발급을 시도하세요"),
     UNSUPPORTED_JWT_TOKEN("UNSUPPORTED_JWT_TOKEN", "지원하지 않는 JWT 토큰 유형입니다."),
     FAILED_TOKEN_VERIFIED("FAILED_TOKEN_VERIFIED", "토큰 검증에 실패했습니다."),

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/CertificationTokenFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/CertificationTokenFilter.java
@@ -77,7 +77,7 @@ public class CertificationTokenFilter extends OncePerRequestFilter {
             return;
         }
 
-        CertificationTokenPayload payload = JwtTokenProvider.extractCertificationTokenPayloadIgnoringExpiration(token);
+        CertificationTokenPayload payload = JwtTokenProvider.extractCertificationTokenPayloadIgnoringExpiredExpiration(token);
         context.updateFromTokenClaims(
             payload.getAppName(),
             payload.getApiPermission(),

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/SessionCheckFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/SessionCheckFilter.java
@@ -29,13 +29,13 @@ public class SessionCheckFilter extends OncePerRequestFilter {
         // 1. 요청 헤더로부터 Session Token 가져오기
         String sessionToken = parseBearerToken(request);
 
-        if (sessionToken == null) {
-            log.debug("헤더로부터 SessionToken을 추출하는데 실패했습니다. URI: {}, Header value: {}", request.getRequestURI(), request.getHeader(AUTHORIZATION_HEADER));
-            filterChain.doFilter(request, response);
-            return;
-        }
-
         try {
+            if (sessionToken == null) {
+                log.debug("헤더로부터 SessionToken을 추출하는데 실패했습니다. URI: {}, Header value: {}", request.getRequestURI(), request.getHeader(AUTHORIZATION_HEADER));
+                filterChain.doFilter(request, response);
+                return;
+            }
+
             // 2. Session Token 파싱
             VerifyTokenResult verifyTokenResult = verifyToken(sessionToken);
             if (verifyTokenResult != VERIFIED_TOKEN) {

--- a/src/main/java/com/eventty/eventtynextgen/base/filter/SessionCheckFilter.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/filter/SessionCheckFilter.java
@@ -1,35 +1,19 @@
 package com.eventty.eventtynextgen.base.filter;
 
 import static com.eventty.eventtynextgen.base.constant.BaseConst.*;
-import static com.eventty.eventtynextgen.base.exception.enums.AuthErrorType.FAILED_TOKEN_VERIFIED;
-import static com.eventty.eventtynextgen.base.exception.enums.AuthErrorType.ILLEGAL_STATE_JWT_TOKEN;
-import static com.eventty.eventtynextgen.base.exception.enums.AuthErrorType.INVALID_SIGNATURE_JWT_TOKEN;
-import static com.eventty.eventtynextgen.base.exception.enums.AuthErrorType.JWT_TOKEN_EXPIRED;
-import static com.eventty.eventtynextgen.base.exception.enums.AuthErrorType.UNSUPPORTED_JWT_TOKEN;
 import static com.eventty.eventtynextgen.shared.provider.JwtTokenProvider.*;
 import static com.eventty.eventtynextgen.shared.provider.JwtTokenProvider.VerifyTokenResult.VERIFIED_TOKEN;
 
-import com.eventty.eventtynextgen.shared.provider.JwtTokenProvider;
 import com.eventty.eventtynextgen.shared.provider.JwtTokenProvider.VerifyTokenResult;
-import com.eventty.eventtynextgen.base.utils.ResponseUtils;
-import com.eventty.eventtynextgen.shared.component.user.UserComponent;
-import com.eventty.eventtynextgen.shared.context.SessionContext;
 import com.eventty.eventtynextgen.shared.context.SessionContextHolder;
-import com.eventty.eventtynextgen.base.exception.CustomException;
-import com.eventty.eventtynextgen.base.exception.enums.AuthErrorType;
-import com.eventty.eventtynextgen.base.exception.enums.UserErrorType;
-import com.eventty.eventtynextgen.shared.utils.LoggerUtils;
-import com.eventty.eventtynextgen.user.entity.User;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -40,40 +24,30 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 public class SessionCheckFilter extends OncePerRequestFilter {
 
-    private final UserComponent userComponent;
-    private final ResponseUtils responseUtils;
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         // 1. 요청 헤더로부터 Session Token 가져오기
         String sessionToken = parseBearerToken(request);
 
         if (sessionToken == null) {
+            log.debug("헤더로부터 SessionToken을 추출하는데 실패했습니다. URI: {}, Header value: {}", request.getRequestURI(), request.getHeader(AUTHORIZATION_HEADER));
             filterChain.doFilter(request, response);
             return;
         }
 
-        // 2. Session Token 파싱
-        if (!verifySessionToken(sessionToken, response)) {
-            return;
-        }
-
-        // 3. userId를 통해 사용자 조회
-        User user = getUserBySessionToken(sessionToken, response);
-        if (user == null) {
-            return;
-        }
-
-        // 4. 사용자 검증
-        if (!validateUser(user, response)) {
-            return;
-        }
-
         try {
-            // 5. Context 업데이트
-            SessionContext sessionContext = SessionContextHolder.getContext();
-            sessionContext.updateSessionInfo(user.getId(), user.getUserRole().name());
+            // 2. Session Token 파싱
+            VerifyTokenResult verifyTokenResult = verifyToken(sessionToken);
+            if (verifyTokenResult != VERIFIED_TOKEN) {
+                log.debug("SessionToken 검증에 실패했습니다. URI: {}, VerifyTokenResult: {}", request.getRequestURI(), verifyTokenResult);
+                SessionContextHolder.getContext().updateSessionInfo(sessionToken, verifyTokenResult);
+                filterChain.doFilter(request, response);
+                return;
+            }
 
+            // 3. Session Token으로부터 사용자 ID 추출 및 업데이트
+            Long userId = extractAccessTokenPayloadIgnoringExpiredExpiration(sessionToken).getUserId();
+            SessionContextHolder.getContext().updateSessionInfo(userId, sessionToken, verifyTokenResult);
             filterChain.doFilter(request, response);
         } finally {
             SessionContextHolder.clearContext();
@@ -83,65 +57,12 @@ public class SessionCheckFilter extends OncePerRequestFilter {
     private String parseBearerToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
 
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(JWT_TOKEN_TYPE)) {
-            return bearerToken.substring(JWT_TOKEN_TYPE.length() + 1);
+        int beginIndex = JWT_TOKEN_TYPE.length() + 1;
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.length() > beginIndex && bearerToken.startsWith(JWT_TOKEN_TYPE)) {
+            return bearerToken.substring(beginIndex);
         }
 
         return null;
-    }
-
-    private boolean verifySessionToken(String sessionToken, HttpServletResponse response) {
-        VerifyTokenResult verifyTokenResult = verifyToken(sessionToken);
-        if (verifyTokenResult != VERIFIED_TOKEN) {
-            CustomException customException;
-            switch (verifyTokenResult) {
-                case EXPIRED_TOKEN -> {
-                    customException = CustomException.badRequest(JWT_TOKEN_EXPIRED);
-                }
-                case UNSUPPORTED_TOKEN -> {
-                    customException = CustomException.badRequest(UNSUPPORTED_JWT_TOKEN);
-                }
-                case ILLEGAL_STATE_TOKEN -> {
-                    customException = CustomException.badRequest(ILLEGAL_STATE_JWT_TOKEN);
-                }
-                case INVALID_SIGNATURE_TOKEN -> {
-                    customException = CustomException.badRequest(INVALID_SIGNATURE_JWT_TOKEN);
-                }
-                case UNKNOWN_ERROR -> {
-                    customException = CustomException.badRequest(FAILED_TOKEN_VERIFIED);
-                }
-                default -> {
-                    customException = CustomException.of(HttpStatus.INTERNAL_SERVER_ERROR, AuthErrorType.UNKNOWN_EXCEPTION);
-                }
-            }
-            LoggerUtils.info(customException);
-            this.responseUtils.writeErrorResponseToResponse(response, customException);
-            return false;
-        }
-
-        return true;
-    }
-    private User getUserBySessionToken(String sessionToken, HttpServletResponse response) {
-        Long userId = extractAccessTokenPayloadIgnoringExpiration(sessionToken).getUserId();
-        Optional<User> userOpt = userComponent.getUserByUserId(userId);
-
-        if (userOpt.isEmpty()) {
-            CustomException customException = CustomException.badRequest(UserErrorType.NOT_FOUND_USER);
-            LoggerUtils.info(customException, "Session Check Filter - 사용자 조회 실패");
-            this.responseUtils.writeErrorResponseToResponse(response, customException);
-            return null;
-        }
-
-        return userOpt.get();
-    }
-    private boolean validateUser(User user, HttpServletResponse response) {
-        if (user.isDeleted()) {
-            CustomException customException = CustomException.badRequest(UserErrorType.USER_ALREADY_DELETED);
-            LoggerUtils.info(customException, "Session Check Filter - 삭제된 사용자");
-            this.responseUtils.writeErrorResponseToResponse(response, customException);
-            return false;
-        }
-
-        return true;
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/shared/context/SessionContext.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/context/SessionContext.java
@@ -1,23 +1,36 @@
 package com.eventty.eventtynextgen.shared.context;
 
+import static com.eventty.eventtynextgen.shared.provider.JwtTokenProvider.*;
+
 import java.util.Objects;
 import lombok.Getter;
-import org.springframework.util.StringUtils;
 
 @Getter
 public class SessionContext {
 
     private Long userId;
     private String role;
+    private String sessionToken;
+    private VerifyTokenResult verifyTokenResult;
 
     public SessionContext() {}
 
-    public void updateSessionInfo(Long userId, String role) {
+    public void updateSessionInfo(Long userId, String sessionToken, VerifyTokenResult verifyTokenResult) {
         this.userId = userId;
+        this.sessionToken = sessionToken;
+        this.verifyTokenResult = verifyTokenResult;
+    }
+
+    public void updateSessionInfo(String sessionToken, VerifyTokenResult verifyTokenResult) {
+        this.sessionToken = sessionToken;
+        this.verifyTokenResult = verifyTokenResult;
+    }
+
+    public void updateRole(String role) {
         this.role = role;
     }
 
-    public boolean validate() {
-        return Objects.nonNull(this.userId) && StringUtils.hasText(role);
+    public boolean isSuccessParsingToken() {
+        return this.getVerifyTokenResult() == VerifyTokenResult.VERIFIED_TOKEN;
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/shared/provider/JwtTokenProvider.java
+++ b/src/main/java/com/eventty/eventtynextgen/shared/provider/JwtTokenProvider.java
@@ -1,6 +1,6 @@
 package com.eventty.eventtynextgen.shared.provider;
 
-import static com.eventty.eventtynextgen.base.exception.enums.AuthErrorType.FAIL_VERIFY_JWT_TOKEN;
+import static com.eventty.eventtynextgen.base.exception.enums.AuthErrorType.FAIL_PARSING_JWT_TOKEN;
 import static com.eventty.eventtynextgen.shared.constant.SharedConst.OBJECT_MAPPER;
 import static com.eventty.eventtynextgen.shared.utils.sequence.Assertions.notNull;
 
@@ -23,6 +23,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 
 @Slf4j
 @UtilityClass
@@ -57,10 +58,11 @@ public class JwtTokenProvider {
         return new SessionTokenInfo(JWT_TOKEN_TYPE, accessToken, accessTokenExpiredAt, refreshToken, refreshTokenExpiredAt);
     }
 
-    public static AccessTokenPayload extractAccessTokenPayloadIgnoringExpiration(String accessToken) {
+    public static AccessTokenPayload extractAccessTokenPayloadIgnoringExpiredExpiration(String accessToken) {
         Claims claims = parseClaims(accessToken);
         if (claims == null) {
-            throw CustomException.badRequest(FAIL_VERIFY_JWT_TOKEN);
+            log.error("토큰 파싱에 실패했습니다. 토큰을 파싱하기 앞서 Access Token에 대한 검증을 우선시 해주세요. access Token: {}", accessToken);
+            throw CustomException.of(HttpStatus.INTERNAL_SERVER_ERROR, FAIL_PARSING_JWT_TOKEN);
         }
 
         Long userId = claims.get(JWT_CLAIM_USER_ID_KEY, Long.class);
@@ -136,11 +138,12 @@ public class JwtTokenProvider {
         return new CertificationTokenInfo(JWT_TOKEN_TYPE, certificationToken);
     }
 
-    public static CertificationTokenPayload extractCertificationTokenPayloadIgnoringExpiration(String certificationToken) {
+    public static CertificationTokenPayload extractCertificationTokenPayloadIgnoringExpiredExpiration(String certificationToken) {
         Claims claims = parseClaims(certificationToken);
 
         if (claims == null) {
-            throw CustomException.badRequest(FAIL_VERIFY_JWT_TOKEN);
+            log.error("토큰 파싱에 실패했습니다. 토큰을 파싱하기 앞서 Certification Token에 대한 검증을 우선시 해주세요. certification Token: {}", certificationToken);
+            throw CustomException.of(HttpStatus.INTERNAL_SERVER_ERROR, FAIL_PARSING_JWT_TOKEN);
         }
 
         String appName = claims.get(APP_NAME_KEY, String.class);

--- a/src/test/java/com/eventty/eventtynextgen/auth/AuthControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/auth/AuthControllerTest.java
@@ -235,7 +235,7 @@ class AuthControllerTest {
                 .header(CERTIFICATION_TOKEN_COOKIE_NAME, certificationToken.getCertificationToken()));
 
             // then
-            resultActions.andExpect(status().isForbidden());
+            resultActions.andExpect(status().isUnauthorized());
         }
     }
 

--- a/src/test/java/com/eventty/eventtynextgen/base/aspect/LoginRequiredAspectTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/aspect/LoginRequiredAspectTest.java
@@ -8,16 +8,29 @@ import static org.mockito.Mockito.when;
 import com.eventty.eventtynextgen.base.annotation.LoginRequired;
 import com.eventty.eventtynextgen.base.exception.CustomException;
 import com.eventty.eventtynextgen.base.exception.enums.AuthErrorType;
+import com.eventty.eventtynextgen.base.exception.enums.UserErrorType;
+import com.eventty.eventtynextgen.shared.component.user.UserComponent;
+import com.eventty.eventtynextgen.shared.context.SessionContext;
 import com.eventty.eventtynextgen.shared.context.SessionContextHolder;
+import com.eventty.eventtynextgen.shared.provider.JwtTokenProvider.VerifyTokenResult;
+import com.eventty.eventtynextgen.user.entity.User;
 import com.eventty.eventtynextgen.user.entity.enums.UserRoleType;
+import java.util.Optional;
 import org.aspectj.lang.JoinPoint;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("LoginRequiredAspect 클래스 테스트")
 class LoginRequiredAspectTest {
+
+    @Mock
+    private UserComponent userComponent;
 
     @BeforeEach
     void setUp() {
@@ -29,122 +42,306 @@ class LoginRequiredAspectTest {
     class CheckAuthority {
 
         @Test
-        @DisplayName("로그인이 필요하지 않다면 별다른 검증이 이루어지지 않는다.")
-        void 로그인이_필요하지_않다면_별다른_검증이_이루어지지_않는다() {
+        @DisplayName("로그인 검증이 필요하지 않는 API라면 검증에 통과하며 Context에 사용자 역할 정보가 업데이트된다")
+        void 로그인_검증이_필요하지_않는_API라면_검증에_통과하며_Context에_사용자_역할_정보가_업데이트된다() {
             // given
             JoinPoint joinPoint = mock(JoinPoint.class);
             LoginRequired loginRequired = mock(LoginRequired.class);
 
             when(loginRequired.requireLogin()).thenReturn(false);
 
-            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect();
+            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect(userComponent);
 
-            // when & then
+            // when  & then
             loginRequiredAspect.checkAuthority(joinPoint, loginRequired);
         }
 
         @Test
-        @DisplayName("로그인이 필요하고 권한은 필요없을 때 사용자 정보가 존재한다면 통과한다")
-        void 로그인이_필요하고_권한은_필요없을_때_사용자_정보가_존재한다면_통과한다() {
+        @DisplayName("로그인 검증만 필요하고 사용자 조회 및 검증에 성공했다면 검증에 통과하며 Context에 사용자 역할 정보가 업데이트된다")
+        void 로그인_검증만_필요하고_사용자_조회_및_검증에_성공했다면_검증에_통과하며_Context에_사용자_역할_정보가_업데이트된다() {
             // given
             JoinPoint joinPoint = mock(JoinPoint.class);
             LoginRequired loginRequired = mock(LoginRequired.class);
+            Long userId = 1L;
 
-            SessionContextHolder.getContext().updateSessionInfo(1L, UserRoleType.USER.name());
+            User user = mock(User.class);
+            when(user.isDeleted()).thenReturn(false);
+            when(user.getUserRole()).thenReturn(UserRoleType.USER);
+
+            SessionContextHolder.getContext().updateSessionInfo(userId, "session_token", VerifyTokenResult.VERIFIED_TOKEN);
+            SessionContext context = SessionContextHolder.getContext();
 
             when(loginRequired.requireLogin()).thenReturn(true);
+            when(userComponent.getUserByUserId(context.getUserId())).thenReturn(Optional.of(user));
 
-            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect();
+            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect(userComponent);
 
-            // when & then
+            // when
             loginRequiredAspect.checkAuthority(joinPoint, loginRequired);
+
+            // then
+            assertThat(SessionContextHolder.getContext().getRole()).isEqualTo(UserRoleType.USER.name());
         }
 
         @Test
-        @DisplayName("로그인이 필요하고 권한은 필요없을 때 사용자 정보가 존재하지 않다면 예외가 발생한다")
-        void 로그인이_필요하고_권한은_필요없을_때_사용자_정보가_존재하지_않다면_예외가_발생한다() {
+        @DisplayName("로그인 검증과 역할 검증이 필요하고 사용자 조회 및 검증에 성공한 뒤 역할 검증에도 성공한다면 검증 통과하며 Context에 사용자 역할 정보가 업데이트된다")
+        void 로그인_검증과_역할_검증이_필요하고_사용자_조회_및_검증에_성공한_뒤_역할_검증에도_성공한다면_검증_통과하며_Context에_사용자_역할_정보가_업데이트된다() {
+            // given
+            JoinPoint joinPoint = mock(JoinPoint.class);
+            LoginRequired loginRequired = mock(LoginRequired.class);
+            Long userId = 1L;
+
+            User user = mock(User.class);
+            when(user.isDeleted()).thenReturn(false);
+            when(user.getUserRole()).thenReturn(UserRoleType.USER);
+
+            SessionContextHolder.getContext().updateSessionInfo(userId, "session_token", VerifyTokenResult.VERIFIED_TOKEN);
+            SessionContext context = SessionContextHolder.getContext();
+
+            when(loginRequired.requireLogin()).thenReturn(true);
+            when(userComponent.getUserByUserId(context.getUserId())).thenReturn(Optional.of(user));
+
+            when(loginRequired.requireAdmin()).thenReturn(true);
+            when(loginRequired.requireHost()).thenReturn(true);
+            when(loginRequired.requireUser()).thenReturn(true);
+
+            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect(userComponent);
+
+            // when
+            loginRequiredAspect.checkAuthority(joinPoint, loginRequired);
+
+            // then
+            assertThat(SessionContextHolder.getContext().getRole()).isEqualTo(UserRoleType.USER.name());
+        }
+
+        @Test
+        @DisplayName("로그인 검증이 필요하지만 Session Context에 존재하는 파싱 결과가 존재하지 않다면 검증에 싪채하고 예외가 발생한다")
+        void 검증이_필요하지만_Session_Context에_존재하는_파싱_결과가_존재하지_않다면_검증에_싪채하고_예외가_발생한다() {
             // given
             JoinPoint joinPoint = mock(JoinPoint.class);
             LoginRequired loginRequired = mock(LoginRequired.class);
 
+            SessionContextHolder.getContext().updateSessionInfo("session_token", null);
+            SessionContext context = SessionContextHolder.getContext();
+
             when(loginRequired.requireLogin()).thenReturn(true);
 
-            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect();
+            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect(userComponent);
 
             // when & then
             assertThatThrownBy(() -> loginRequiredAspect.checkAuthority(joinPoint, loginRequired))
+                .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
-                    assertThat(ex).isInstanceOf(CustomException.class);
                     CustomException customException = (CustomException) ex;
-                    assertThat(customException.getHttpStatus().value()).isEqualTo(403);
+                    assertThat(customException.getHttpStatus().value()).isEqualTo(401);
                     assertThat(customException.getErrorType()).isEqualTo(AuthErrorType.LOGIN_REQUIRED_API);
                 });
         }
 
         @Test
-        @DisplayName("로그인 검증에 성공하고 Admin 권한 검증에 성공할 경우 통과한다")
-        void 로그인_검증에_성공하고_Admin_권한_검증에_성공할_경우_통과한다() {
+        @DisplayName("로그인 검증이 필요하지만 Session Context에 존재하는 파싱 결과가 EXPIRED_TOKEN이라면 검증에 실패하고 예외가 발생한다")
+        void 로그인_검증이_필요하지만_Session_Context에_존재하는_파싱_결과가_EXPIRED_TOKEN이라면_검증에_실패하고_예외가_발생한다() {
             // given
             JoinPoint joinPoint = mock(JoinPoint.class);
             LoginRequired loginRequired = mock(LoginRequired.class);
 
-            SessionContextHolder.getContext().updateSessionInfo(1L, UserRoleType.ADMIN.name());
+            SessionContextHolder.getContext().updateSessionInfo("session_token", VerifyTokenResult.EXPIRED_TOKEN);
+            SessionContext context = SessionContextHolder.getContext();
 
             when(loginRequired.requireLogin()).thenReturn(true);
-            when(loginRequired.requireAdmin()).thenReturn(true);
 
-            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect();
-        }
-
-        @Test
-        @DisplayName("로그인 검증에 성공하고 Host 권한 검증에 성공할 경우 통과한다")
-        void 로그인_검증에_성공하고_Host_권한_검증에_성공할_경우_통과한다() {
-            // given
-            JoinPoint joinPoint = mock(JoinPoint.class);
-            LoginRequired loginRequired = mock(LoginRequired.class);
-
-            SessionContextHolder.getContext().updateSessionInfo(1L, UserRoleType.HOST.name());
-
-            when(loginRequired.requireLogin()).thenReturn(true);
-            when(loginRequired.requireHost()).thenReturn(true);
-
-            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect();
-        }
-
-        @Test
-        @DisplayName("로그인 검증에 성공하고 User 권한 검증에 성공할 경우 통과한다")
-        void 로그인_검증에_성공하고_User_권한_검증에_성공할_경우_통과한다() {
-            // given
-            JoinPoint joinPoint = mock(JoinPoint.class);
-            LoginRequired loginRequired = mock(LoginRequired.class);
-
-            SessionContextHolder.getContext().updateSessionInfo(1L, UserRoleType.USER.name());
-
-            when(loginRequired.requireLogin()).thenReturn(true);
-            when(loginRequired.requireUser()).thenReturn(true);
-
-            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect();
-        }
-
-        @Test
-        @DisplayName("로그인 검증에 성공하지만 권한 검증에 실패할 경우 통과하지 못한다")
-        void 로그인_검증에_성공하지만_권한_검증에_실패할_경우_통과하지_못한다() {
-            // given
-            JoinPoint joinPoint = mock(JoinPoint.class);
-            LoginRequired loginRequired = mock(LoginRequired.class);
-
-            SessionContextHolder.getContext().updateSessionInfo(1L, UserRoleType.USER.name());
-
-            when(loginRequired.requireLogin()).thenReturn(true);
-            when(loginRequired.requireAdmin()).thenReturn(true);
-            when(loginRequired.requireHost()).thenReturn(true);
-
-            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect();
+            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect(userComponent);
 
             // when & then
             assertThatThrownBy(() -> loginRequiredAspect.checkAuthority(joinPoint, loginRequired))
+                .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
-                    assertThat(ex).isInstanceOf(CustomException.class);
+                    CustomException customException = (CustomException) ex;
+                    assertThat(customException.getHttpStatus().value()).isEqualTo(401);
+                    assertThat(customException.getErrorType()).isEqualTo(AuthErrorType.JWT_TOKEN_EXPIRED);
+                });
+        }
+
+        @Test
+        @DisplayName("로그인 검증이 필요하지만 Session Context에 존재하는 파싱 결과가 UNSUPPORTED_TOKEN이라면 검증에 실패하고 예외가 발생한다")
+        void 로그인_검증이_필요하지만_Session_Context에_존재하는_파싱_결과가_UNSUPPORTED_TOKEN이라면_검증에_실패하고_예외가_발생한다() {
+            // given
+            JoinPoint joinPoint = mock(JoinPoint.class);
+            LoginRequired loginRequired = mock(LoginRequired.class);
+
+            SessionContextHolder.getContext().updateSessionInfo("session_token", VerifyTokenResult.UNSUPPORTED_TOKEN);
+            SessionContext context = SessionContextHolder.getContext();
+
+            when(loginRequired.requireLogin()).thenReturn(true);
+
+            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect(userComponent);
+
+            // when & then
+            assertThatThrownBy(() -> loginRequiredAspect.checkAuthority(joinPoint, loginRequired))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customException = (CustomException) ex;
+                    assertThat(customException.getHttpStatus().value()).isEqualTo(401);
+                    assertThat(customException.getErrorType()).isEqualTo(AuthErrorType.UNSUPPORTED_JWT_TOKEN);
+                });
+        }
+
+        @Test
+        @DisplayName("로그인 검증이 필요하지만 Session Context에 존재하는 파싱 결과가 ILLEGAL_STATE_TOKEN이라면 검증에 실패하고 예외가 발생한다")
+        void 로그인_검증이_필요하지만_Session_Context에_존재하는_파싱_결과가_ILLEGAL_STATE_TOKEN이라면_검증에_실패하고_예외가_발생한다() {
+            // given
+            JoinPoint joinPoint = mock(JoinPoint.class);
+            LoginRequired loginRequired = mock(LoginRequired.class);
+
+            SessionContextHolder.getContext().updateSessionInfo("session_token", VerifyTokenResult.ILLEGAL_STATE_TOKEN);
+            SessionContext context = SessionContextHolder.getContext();
+
+            when(loginRequired.requireLogin()).thenReturn(true);
+
+            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect(userComponent);
+
+            // when & then
+            assertThatThrownBy(() -> loginRequiredAspect.checkAuthority(joinPoint, loginRequired))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customException = (CustomException) ex;
+                    assertThat(customException.getHttpStatus().value()).isEqualTo(401);
+                    assertThat(customException.getErrorType()).isEqualTo(AuthErrorType.ILLEGAL_STATE_JWT_TOKEN);
+                });
+        }
+
+        @Test
+        @DisplayName("로그인 검증이 필요하지만 Session Context에 존재하는 파싱 결과가 INVALID_SIGNATURE_TOKEN이라면 검증에 실패하고 예외가 발생한다")
+        void 로그인_검증이_필요하지만_Session_Context에_존재하는_파싱_결과가_INVALID_SIGNATURE_TOKEN이라면_검증에_실패하고_예외가_발생한다() {
+            // given
+            JoinPoint joinPoint = mock(JoinPoint.class);
+            LoginRequired loginRequired = mock(LoginRequired.class);
+
+            SessionContextHolder.getContext().updateSessionInfo("session_token", VerifyTokenResult.INVALID_SIGNATURE_TOKEN);
+            SessionContext context = SessionContextHolder.getContext();
+
+            when(loginRequired.requireLogin()).thenReturn(true);
+
+            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect(userComponent);
+
+            // when & then
+            assertThatThrownBy(() -> loginRequiredAspect.checkAuthority(joinPoint, loginRequired))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customException = (CustomException) ex;
+                    assertThat(customException.getHttpStatus().value()).isEqualTo(401);
+                    assertThat(customException.getErrorType()).isEqualTo(AuthErrorType.INVALID_SIGNATURE_JWT_TOKEN);
+                });
+        }
+
+        @Test
+        @DisplayName("로그인 검증이 필요하지만 Session Context에 존재하는 파싱 결과가 UNKNOWN_ERROR이라면 검증에 실패하고 예외가 발생한다")
+        void 로그인_검증이_필요하지만_Session_Context에_존재하는_파싱_결과가_UNKNOWN_ERROR이라면_검증에_실패하고_예외가_발생한다() {
+            // given
+            JoinPoint joinPoint = mock(JoinPoint.class);
+            LoginRequired loginRequired = mock(LoginRequired.class);
+
+            SessionContextHolder.getContext().updateSessionInfo("session_token", VerifyTokenResult.UNKNOWN_ERROR);
+            SessionContext context = SessionContextHolder.getContext();
+
+            when(loginRequired.requireLogin()).thenReturn(true);
+
+            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect(userComponent);
+
+            // when & then
+            assertThatThrownBy(() -> loginRequiredAspect.checkAuthority(joinPoint, loginRequired))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customException = (CustomException) ex;
+                    assertThat(customException.getHttpStatus().value()).isEqualTo(401);
+                    assertThat(customException.getErrorType()).isEqualTo(AuthErrorType.FAILED_TOKEN_VERIFIED);
+                });
+        }
+
+
+        @Test
+        @DisplayName("로그인 검증이 필요하여 사용자 조회 결과 사용자를 찾지 못한다면 검증에 실패하고 예외가 발생한다")
+        void 로그인_검증이_필요하여_사용자_조회_결과_사용자를_찾지_못한다면_검증에_실패하고_예외가_발생한다() {
+            // given
+            JoinPoint joinPoint = mock(JoinPoint.class);
+            LoginRequired loginRequired = mock(LoginRequired.class);
+            Long userId = 1L;
+
+            SessionContextHolder.getContext().updateSessionInfo(userId, "session_token", VerifyTokenResult.VERIFIED_TOKEN);
+            SessionContext context = SessionContextHolder.getContext();
+
+            when(loginRequired.requireLogin()).thenReturn(true);
+            when(userComponent.getUserByUserId(context.getUserId())).thenReturn(Optional.empty());
+
+            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect(userComponent);
+
+            // when & then
+            assertThatThrownBy(() -> loginRequiredAspect.checkAuthority(joinPoint, loginRequired))
+                .isInstanceOf(CustomException.class)
+                .satisfies((ex) -> {
+                    CustomException customException = (CustomException) ex;
+                    assertThat(customException.getHttpStatus().value()).isEqualTo(401);
+                    assertThat(customException.getErrorType()).isEqualTo(UserErrorType.NOT_FOUND_USER);
+                });
+        }
+
+        @Test
+        @DisplayName("로그인 검증이 필요하며 사용자 조회 결과 사용자를 찾았지만 유효한 사용자가 아니라면 검증에 실패하고 예외가 발생한다")
+        void 로그인_검증이_필요하며_사용자_조회_결과_사용자를_찾았지만_유효한_사용자가_아니라면_검증에_실패하고_예외가_발생한다() {
+            // given
+            JoinPoint joinPoint = mock(JoinPoint.class);
+            LoginRequired loginRequired = mock(LoginRequired.class);
+            Long userId = 1L;
+
+            User user = mock(User.class);
+            when(user.isDeleted()).thenReturn(true);
+
+            SessionContextHolder.getContext().updateSessionInfo(userId, "session_token", VerifyTokenResult.VERIFIED_TOKEN);
+            SessionContext context = SessionContextHolder.getContext();
+
+            when(loginRequired.requireLogin()).thenReturn(true);
+            when(userComponent.getUserByUserId(context.getUserId())).thenReturn(Optional.of(user));
+
+            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect(userComponent);
+
+            // when & then
+            assertThatThrownBy(() -> loginRequiredAspect.checkAuthority(joinPoint, loginRequired))
+                .isInstanceOf(CustomException.class)
+                .satisfies((ex) -> {
+                    CustomException customException = (CustomException) ex;
+                    assertThat(customException.getHttpStatus().value()).isEqualTo(401);
+                    assertThat(customException.getErrorType()).isEqualTo(UserErrorType.USER_ALREADY_DELETED);
+                });
+        }
+
+        @Test
+        @DisplayName("로그인 검증과 역할 검증이 필요하고 사용자의 모든 검증에 성공했지만 역할 검증에 실패핟다면 검증은 실패하고 예외가 발생한다")
+        void 로그인_검증과_역할_검증이_필요하고_사용자의_모든_검증에_성공했지만_역할_검증에_실패핟다면_검증은_실패하고_예외가_발생한다() {
+            // given
+            JoinPoint joinPoint = mock(JoinPoint.class);
+            LoginRequired loginRequired = mock(LoginRequired.class);
+            Long userId = 1L;
+
+            User user = mock(User.class);
+            when(user.isDeleted()).thenReturn(false);
+            when(user.getUserRole()).thenReturn(UserRoleType.USER);
+
+            SessionContextHolder.getContext().updateSessionInfo(userId, "session_token", VerifyTokenResult.VERIFIED_TOKEN);
+            SessionContext context = SessionContextHolder.getContext();
+
+            when(loginRequired.requireLogin()).thenReturn(true);
+            when(userComponent.getUserByUserId(context.getUserId())).thenReturn(Optional.of(user));
+
+            when(loginRequired.requireAdmin()).thenReturn(true);
+            when(loginRequired.requireHost()).thenReturn(true);
+            when(loginRequired.requireUser()).thenReturn(false);
+
+            LoginRequiredAspect loginRequiredAspect = new LoginRequiredAspect(userComponent);
+
+            // when & then
+            assertThatThrownBy(() -> loginRequiredAspect.checkAuthority(joinPoint, loginRequired))
+                .isInstanceOf(CustomException.class)
+                .satisfies((ex) -> {
                     CustomException customException = (CustomException) ex;
                     assertThat(customException.getHttpStatus().value()).isEqualTo(403);
                     assertThat(customException.getErrorType()).isEqualTo(AuthErrorType.AUTH_USER_NOT_AUTHORIZED);

--- a/src/test/java/com/eventty/eventtynextgen/base/filter/SessionCheckFilterTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/filter/SessionCheckFilterTest.java
@@ -9,12 +9,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.eventty.eventtynextgen.base.fixture.SessionTokenFixture;
 import com.eventty.eventtynextgen.shared.provider.JwtTokenProvider;
 import com.eventty.eventtynextgen.shared.provider.JwtTokenProvider.SessionTokenInfo;
 import com.eventty.eventtynextgen.base.utils.ResponseUtils;
 import com.eventty.eventtynextgen.shared.component.user.UserComponent;
 import com.eventty.eventtynextgen.shared.context.SessionContext;
 import com.eventty.eventtynextgen.shared.context.SessionContextHolder;
+import com.eventty.eventtynextgen.shared.provider.JwtTokenProvider.VerifyTokenResult;
 import com.eventty.eventtynextgen.user.entity.User;
 import com.eventty.eventtynextgen.user.entity.enums.UserRoleType;
 import jakarta.servlet.FilterChain;
@@ -23,6 +25,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,11 +36,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayName("Seesion Check Filter 단위 테스트")
 class SessionCheckFilterTest {
 
-    @Mock
-    private UserComponent userComponent;
-
-    @Mock
-    private ResponseUtils responseUtils;
+    @BeforeEach
+    void setUp() {
+        SessionContextHolder.clearContext();
+    }
 
     @Test
     @DisplayName("Session Token이 존재하지 않는 경우 요청은 넘어간다.")
@@ -49,7 +51,7 @@ class SessionCheckFilterTest {
 
         when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(null);
 
-        SessionCheckFilter sessionCheckFilter = new SessionCheckFilter(userComponent, responseUtils);
+        SessionCheckFilter sessionCheckFilter = new SessionCheckFilter();
 
         // when
         sessionCheckFilter.doFilterInternal(request, response, filterChain);
@@ -59,35 +61,63 @@ class SessionCheckFilterTest {
     }
 
     @Test
-    @DisplayName("Session Token의 유효성 검증과 사용자 검증이 성공할 경우 Context는 업데이트되고 요청은 넘어간다")
-    void Session_Token의_유효성_검증과_사용자_검증이_성공할_경우_Context는_업데이트되고_요청은_넘어간다() throws ServletException, IOException {
+    @DisplayName("Session Token의 유효성 검증에 성공할 경우 Context에 SessionToken과 userId 그리고 검증결과가 업데이트되고 요청이 넘어간다")
+    void Session_Token의_유효성_검증에_성공할_경우_Context에_SessionToken과_userId와_검증결과가_업데이트되고_요청이_넘어간다() throws ServletException, IOException {
         // given
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
         FilterChain filterChain = mock(FilterChain.class);
-        User user = mock(User.class);
 
         Long userId = 1L;
-        UserRoleType userRoleType = UserRoleType.USER;
         SessionTokenInfo sessionToken = JwtTokenProvider.createSessionToken(userId, 60 * 1000L, 60 * 1000L);
-        String accessTokenHeaderValue = sessionToken.getTokenType() + "  " + sessionToken.getAccessToken();
+        String accessTokenHeaderValue = sessionToken.getTokenType() + " " + sessionToken.getAccessToken();
 
         when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(accessTokenHeaderValue);
-        when(userComponent.getUserByUserId(userId)).thenReturn(Optional.of(user));
-        when(user.isDeleted()).thenReturn(false);
-        when(user.getId()).thenReturn(userId);
-        when(user.getUserRole()).thenReturn(userRoleType);
 
         doAnswer(invocation -> {
             // doFilter() 직전에 Context 상태 확인
             SessionContext sessionContext = SessionContextHolder.getContext();
             assertThat(sessionContext.getUserId()).isEqualTo(userId);
-            assertThat(sessionContext.getRole()).isEqualTo(userRoleType.name());
+            assertThat(sessionContext.getVerifyTokenResult()).isEqualTo(VerifyTokenResult.VERIFIED_TOKEN);
+            assertThat(sessionContext.getSessionToken()).isEqualTo(sessionToken.getAccessToken());
 
             return null;
         }).when(filterChain).doFilter(request, response);
 
-        SessionCheckFilter sessionCheckFilter = new SessionCheckFilter(userComponent, responseUtils);
+        // when
+        SessionCheckFilter sessionCheckFilter = new SessionCheckFilter();
+        sessionCheckFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Session Token의 만료 시간이 지난 경우 Context에 SessionToken과 검증결과가 업데이트되고 요청이 넘어간다")
+    void Session_Token의_만료_시간이_지난_경우_Context에_SessionToken과_검증결과가_업데이트되고_요청이_넘어간다() throws ServletException, IOException {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+
+        Long userId = 1L;
+        SessionTokenInfo sessionToken = JwtTokenProvider.createSessionToken(userId, -60 * 1000L, -60 * 1000L);
+        String accessTokenHeaderValue = sessionToken.getTokenType() + " " + sessionToken.getAccessToken();
+
+        when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(accessTokenHeaderValue);
+
+        doAnswer(invocation -> {
+            // doFilter() 직전에 Context 상태 확인
+            SessionContext sessionContext = SessionContextHolder.getContext();
+            assertThat(sessionContext.getUserId()).isNull();
+            assertThat(sessionContext.getVerifyTokenResult()).isEqualTo(VerifyTokenResult.EXPIRED_TOKEN);
+            assertThat(sessionContext.getSessionToken()).isEqualTo(sessionToken.getAccessToken());
+
+            return null;
+        }).when(filterChain).doFilter(request, response);
+
+
+        SessionCheckFilter sessionCheckFilter = new SessionCheckFilter();
 
         // when
         sessionCheckFilter.doFilterInternal(request, response, filterChain);
@@ -97,121 +127,65 @@ class SessionCheckFilterTest {
     }
 
     @Test
-    @DisplayName("Session Token의 만료 시간이 지났을 경우 요청은 필터링된다.")
-    void Session_Token의_만료_시간이_지났을_경우_요청은_필터링된다() throws ServletException, IOException {
+    @DisplayName("Session Token이 이상한 문자열로 구성되어 있을 경우 token parsing을 실패하고 요청이 넘어간다")
+    void Session_Token이_이상한_문자열로_구성되어_있을_경우_token_parsing을_실패하고_요청이_넘어간다() throws ServletException, IOException {
         // given
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
         FilterChain filterChain = mock(FilterChain.class);
 
-        Long userId = 1L;
-        SessionTokenInfo sessionToken = JwtTokenProvider.createSessionToken(userId, -60 * 1000L, -60 * 1000L);
-        String accessTokenHeaderValue = sessionToken.getTokenType() + "  " + sessionToken.getAccessToken();
+        String accessTokenHeaderValue = "NOT_SUPPORTED_ACCESS_TOKEN_VALUE";
 
         when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(accessTokenHeaderValue);
 
-        SessionCheckFilter sessionCheckFilter = new SessionCheckFilter(userComponent, responseUtils);
+        doAnswer(invocation -> {
+            // doFilter() 직전에 Context 상태 확인
+            SessionContext sessionContext = SessionContextHolder.getContext();
+            assertThat(sessionContext.getUserId()).isNull();
+            assertThat(sessionContext.getVerifyTokenResult()).isEqualTo(null);
+            assertThat(sessionContext.getSessionToken()).isEqualTo(null);
+
+            return null;
+        }).when(filterChain).doFilter(request, response);
 
         // when
+        SessionCheckFilter sessionCheckFilter = new SessionCheckFilter();
         sessionCheckFilter.doFilterInternal(request, response, filterChain);
 
         // then
-        verify(filterChain, times(0)).doFilter(request, response);
+        verify(filterChain, times(1)).doFilter(request, response);
     }
 
     @Test
-    @DisplayName("Session Token이 이상한 문자열로 되어 있을 경우 요청은 필터링된다.")
-    void Session_Token이_이상한_문자열로_되어_있을_경우_요청은_필터링된다() throws ServletException, IOException {
+    @DisplayName("Session Token의 서명이 잘못되어 있는 경우 Context에 SessionToken과 검증결과가 업데이트되고 요청이 넘어간다")
+    void Session_Token의_서명이_잘못되어_있는_경우_Context에_SessionToken과_검증결과가_업데이트되고_요청이_넘어간다() throws ServletException, IOException {
         // given
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
         FilterChain filterChain = mock(FilterChain.class);
 
-        Long userId = 1L;
-        SessionTokenInfo sessionToken = JwtTokenProvider.createSessionToken(userId, -60 * 1000L, -60 * 1000L);
-        String accessTokenHeaderValue = sessionToken.getTokenType() + "  " + "---" + sessionToken.getAccessToken().substring(3);
+        SessionTokenInfo sessionToken = JwtTokenProvider.createSessionToken(1L, 60 * 1000L, 60 * 1000L);
+        String invalidToken = sessionToken.getAccessToken().substring(0, sessionToken.getAccessToken().lastIndexOf('.') + 1) + "invalidSignature";
+        String accessTokenHeaderValue = sessionToken.getTokenType() + " " + invalidToken;
 
         when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(accessTokenHeaderValue);
 
-        SessionCheckFilter sessionCheckFilter = new SessionCheckFilter(userComponent, responseUtils);
+        doAnswer(invovcation -> {
+            // doFilter() 직전에 Context 상태 확인
+            SessionContext sessionContext = SessionContextHolder.getContext();
+            assertThat(sessionContext.getUserId()).isNull();
+            assertThat(sessionContext.getVerifyTokenResult()).isEqualTo(VerifyTokenResult.INVALID_SIGNATURE_TOKEN);
+            assertThat(sessionContext.getSessionToken()).isEqualTo(invalidToken);
+
+            return null;
+        }).when(filterChain).doFilter(request, response);
+
+        SessionCheckFilter sessionCheckFilter = new SessionCheckFilter();
 
         // when
         sessionCheckFilter.doFilterInternal(request, response, filterChain);
 
         // then
-        verify(filterChain, times(0)).doFilter(request, response);
-    }
-
-    @Test
-    @DisplayName("Session Token의 서명이 잘못되어 있는 경우 요청은 필터링된다.")
-    void Session_Token의_서명이_잘못되어_있는_경우_요청은_필터링된다() throws ServletException, IOException {
-        // given
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        HttpServletResponse response = mock(HttpServletResponse.class);
-        FilterChain filterChain = mock(FilterChain.class);
-
-        Long userId = 1L;
-        SessionTokenInfo sessionToken = JwtTokenProvider.createSessionToken(userId, -60 * 1000L, -60 * 1000L);
-        String accessTokenHeaderValue = sessionToken.getTokenType() + "  " + sessionToken.getAccessToken().substring(3) + "---";
-
-        when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(accessTokenHeaderValue);
-
-        SessionCheckFilter sessionCheckFilter = new SessionCheckFilter(userComponent, responseUtils);
-
-        // when
-        sessionCheckFilter.doFilterInternal(request, response, filterChain);
-
-        // then
-        verify(filterChain, times(0)).doFilter(request, response);
-    }
-
-    @Test
-    @DisplayName("사용자가 삭제되어 있는 경우 요청은 필터링된다.")
-    void 사용자가_삭제되어_있는_경우_요청은_필터링된다() throws ServletException, IOException {
-        // given
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        HttpServletResponse response = mock(HttpServletResponse.class);
-        FilterChain filterChain = mock(FilterChain.class);
-        User user = mock(User.class);
-
-        Long userId = 1L;
-        SessionTokenInfo sessionToken = JwtTokenProvider.createSessionToken(userId, 60 * 1000L, 60 * 1000L);
-        String accessTokenHeaderValue = sessionToken.getTokenType() + "  " + sessionToken.getAccessToken();
-
-        when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(accessTokenHeaderValue);
-        when(userComponent.getUserByUserId(userId)).thenReturn(Optional.of(user));
-        when(user.isDeleted()).thenReturn(true);
-
-        SessionCheckFilter sessionCheckFilter = new SessionCheckFilter(userComponent, responseUtils);
-
-        // when
-        sessionCheckFilter.doFilterInternal(request, response, filterChain);
-
-        // then
-        verify(filterChain, times(0)).doFilter(request, response);
-    }
-
-    @Test
-    @DisplayName("사용자를 찾을 수 없는 경우 요청은 필터링된다.")
-    void 사용자를_찾을_수_없는_경우_요청은_필터링된다() throws ServletException, IOException {
-        // given
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        HttpServletResponse response = mock(HttpServletResponse.class);
-        FilterChain filterChain = mock(FilterChain.class);
-
-        Long userId = 1L;
-        SessionTokenInfo sessionToken = JwtTokenProvider.createSessionToken(userId, 60 * 1000L, 60 * 1000L);
-        String accessTokenHeaderValue = sessionToken.getTokenType() + "  " + sessionToken.getAccessToken();
-
-        when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(accessTokenHeaderValue);
-        when(userComponent.getUserByUserId(userId)).thenReturn(Optional.empty());
-
-        SessionCheckFilter sessionCheckFilter = new SessionCheckFilter(userComponent, responseUtils);
-
-        // when
-        sessionCheckFilter.doFilterInternal(request, response, filterChain);
-
-        // then
-        verify(filterChain, times(0)).doFilter(request, response);
+        verify(filterChain, times(1)).doFilter(request, response);
     }
 }

--- a/src/test/java/com/eventty/eventtynextgen/base/provider/JwtTokenProviderTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/base/provider/JwtTokenProviderTest.java
@@ -1,6 +1,7 @@
 package com.eventty.eventtynextgen.base.provider;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.eventty.eventtynextgen.base.exception.CustomException;
 import com.eventty.eventtynextgen.base.exception.enums.AuthErrorType;
@@ -21,6 +22,7 @@ class JwtTokenProviderTest {
     @Nested
     @DisplayName("Session Token 생성 테스트")
     class CreateSessionToken {
+
         @Test
         @DisplayName("사용자 ID와 액세스 토큰과 리프래시 토큰에 대한 만료 정보를 인자로 받아 Session Token을 생성한다")
         void 사용자_ID와_액세스_토큰과_리프래시_토큰에_대한_만료_정보를_인자로_받아_Session_Token을_생성한다() {
@@ -55,6 +57,7 @@ class JwtTokenProviderTest {
     @Nested
     @DisplayName("Access Token의 페이로드를 추출 테스트")
     class ExtractAccessTokenPayloadIgnoringExpiration {
+
         @Test
         @DisplayName("인자로 들어온 Access Token을 파싱하는데 성공하면 페이로드를 받는다")
         void 인자로_들어온_Access_Token을_파싱하는데_성공하면_페이로드를_받는다() {
@@ -65,7 +68,7 @@ class JwtTokenProviderTest {
             SessionTokenInfo sessionToken = JwtTokenProvider.createSessionToken(userId, accessTokenExpiresIn, refreshTokenExpiresIn);
 
             // when
-            AccessTokenPayload accessTokenPayload = JwtTokenProvider.extractAccessTokenPayloadIgnoringExpiration(sessionToken.getAccessToken());
+            AccessTokenPayload accessTokenPayload = JwtTokenProvider.extractAccessTokenPayloadIgnoringExpiredExpiration(sessionToken.getAccessToken());
 
             // then
             assertThat(accessTokenPayload.getUserId()).isEqualTo(userId);
@@ -81,24 +84,24 @@ class JwtTokenProviderTest {
             SessionTokenInfo sessionToken = JwtTokenProvider.createSessionToken(userId, accessTokenExpiresIn, refreshTokenExpiresIn);
 
             // when
-            AccessTokenPayload accessTokenPayload = JwtTokenProvider.extractAccessTokenPayloadIgnoringExpiration(sessionToken.getAccessToken());
+            AccessTokenPayload accessTokenPayload = JwtTokenProvider.extractAccessTokenPayloadIgnoringExpiredExpiration(sessionToken.getAccessToken());
 
             // then
             assertThat(accessTokenPayload.getUserId()).isEqualTo(userId);
         }
 
         @Test
-        @DisplayName("인자로 들어온 Access Token이 유효하지 않은 문자열일 경우 예외가 발생한다")
-        void 인자로_들어온_Access_Token이_유효하지_않은_문자열일_경우_예외가_발생한다() {
+        @DisplayName("만료된 토큰을 제외한 유효하지 않은 토큰에 대한 파싱은 400 예외가 발생한다")
+        void 만료된_토큰을_제외한_유효하지_않은_토큰에_대한_파싱은_400_예외가_발생한다() {
             // given
             String accessToken = "invalid_access_token";
 
             // when & then
-            assertThatThrownBy(() -> JwtTokenProvider.extractAccessTokenPayloadIgnoringExpiration(accessToken))
+            assertThatThrownBy(() -> JwtTokenProvider.extractAccessTokenPayloadIgnoringExpiredExpiration(accessToken))
                 .satisfies(ex -> {
                     CustomException customException = (CustomException) ex;
-                    assertThat(customException.getHttpStatus().value()).isEqualTo(400);
-                    assertThat(customException.getErrorType()).isEqualTo(AuthErrorType.FAIL_VERIFY_JWT_TOKEN);
+                    assertThat(customException.getHttpStatus().value()).isEqualTo(500);
+                    assertThat(customException.getErrorType()).isEqualTo(AuthErrorType.FAIL_PARSING_JWT_TOKEN);
                 });
         }
     }
@@ -107,6 +110,7 @@ class JwtTokenProviderTest {
     @Nested
     @DisplayName("토큰 검증 테스트")
     class VerifyToken {
+
         @Test
         @DisplayName("토큰 검증에 성공할 경우 VerifyTokenResult.VERIFIED_TOKEN을 반환한다")
         void 토큰_검증에_성공할_경우_VERIFIED_TOKEN을_반환한다() {
@@ -169,6 +173,7 @@ class JwtTokenProviderTest {
     @Nested
     @DisplayName("Certification Token 생성 테스트")
     class CreateCertificationToken {
+
         @Test
         @DisplayName("앱 네임, 호출 권환과 만료 정보를 받아 Certification Token을 생성한다")
         void 앱_네임_호출_권한_만료_정보를_받아_Certification_Token을_생성한다() {
@@ -189,6 +194,7 @@ class JwtTokenProviderTest {
     @Nested
     @DisplayName("Certification Token의 페이로드를 추출 테스트")
     class ExtractCertificationTokenPayloadIgnoringExpiration {
+
         @Test
         @DisplayName("인자로 들어온 certification token을 파싱하는데 성공하면 페이로드를 받는다")
         void 인자로_들어온_certification_token을_파싱하는데_성공하면_페이로드를_받는다() {
@@ -199,7 +205,7 @@ class JwtTokenProviderTest {
             CertificationTokenInfo certificationToken = JwtTokenProvider.createCertificationToken(appName, apiPermissions, certificationTokenValidityInMS);
 
             // when
-            CertificationTokenPayload certificationTokenPayload = JwtTokenProvider.extractCertificationTokenPayloadIgnoringExpiration(
+            CertificationTokenPayload certificationTokenPayload = JwtTokenProvider.extractCertificationTokenPayloadIgnoringExpiredExpiration(
                 certificationToken.getCertificationToken());
 
             // then
@@ -218,7 +224,7 @@ class JwtTokenProviderTest {
             CertificationTokenInfo certificationToken = JwtTokenProvider.createCertificationToken(appName, apiPermissions, certificationTokenValidityInMS);
 
             // when
-            CertificationTokenPayload certificationTokenPayload = JwtTokenProvider.extractCertificationTokenPayloadIgnoringExpiration(
+            CertificationTokenPayload certificationTokenPayload = JwtTokenProvider.extractCertificationTokenPayloadIgnoringExpiredExpiration(
                 certificationToken.getCertificationToken());
 
             // then
@@ -228,17 +234,17 @@ class JwtTokenProviderTest {
         }
 
         @Test
-        @DisplayName("유효하지 않은 certification token이 들어올 경우 예외가 발생한다")
-        void 유효하지_않은_certification_token이_들어올_경우_예외가_발생한다() {
+        @DisplayName("만료된 토큰을 제외한 유효하지 않은 토큰에 대한 파싱은 500 예외가 발생한다")
+        void 만료된_토큰을_제외한_유효하지_않은_토큰에_대한_파싱은_500_예외가_발생한다() {
             // given
             String certificationToken = "invalid_certification_token";
 
             // when & then
-            assertThatThrownBy(() -> JwtTokenProvider.extractCertificationTokenPayloadIgnoringExpiration(certificationToken))
+            assertThatThrownBy(() -> JwtTokenProvider.extractCertificationTokenPayloadIgnoringExpiredExpiration(certificationToken))
                 .satisfies(ex -> {
                     CustomException customException = (CustomException) ex;
-                    assertThat(customException.getHttpStatus().value()).isEqualTo(400);
-                    assertThat(customException.getErrorType()).isEqualTo(AuthErrorType.FAIL_VERIFY_JWT_TOKEN);
+                    assertThat(customException.getHttpStatus().value()).isEqualTo(500);
+                    assertThat(customException.getErrorType()).isEqualTo(AuthErrorType.FAIL_PARSING_JWT_TOKEN);
                 });
         }
     }

--- a/src/test/java/com/eventty/eventtynextgen/user/UserControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/user/UserControllerTest.java
@@ -427,9 +427,8 @@ public class UserControllerTest {
                 .contentType(MediaType.APPLICATION_JSON));
 
             // then
-            resultActions.andExpect(status().isForbidden())
-                .andExpect(
-                    content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
+            resultActions.andExpect(status().isUnauthorized())
+                .andExpect(content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
         }
 
         @Test
@@ -454,7 +453,7 @@ public class UserControllerTest {
                 .contentType(MediaType.APPLICATION_JSON));
 
             // then
-            resultActions.andExpect(status().isBadRequest())
+            resultActions.andExpect(status().isUnauthorized())
                 .andExpect(content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
         }
     }
@@ -497,7 +496,7 @@ public class UserControllerTest {
                 .param("user-id", String.valueOf(1L)));
 
             // then
-            resultActions.andExpect(status().isForbidden())
+            resultActions.andExpect(status().isUnauthorized())
                 .andExpect(content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
         }
 
@@ -521,7 +520,7 @@ public class UserControllerTest {
                 .param("user-id", String.valueOf(userFromDb.getId())));
 
             // then
-            resultActions.andExpect(status().isBadRequest())
+            resultActions.andExpect(status().isUnauthorized())
                 .andExpect(content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
         }
     }


### PR DESCRIPTION
## :bell: Related issues <!-- Please write #[issue_number] -->

#146

## :pencil: Changes and Reasons <!-- Please list what you have changed and why. -->

**API와 상관 없이 무조건적으로 수행되던 토큰 검증 및 필터링 로직 수정**

로그인이 필요하지 않은 API는 유효하지 않은 토큰이 존재하더라도 사용자에게 제공되어야 한다. 하지만 이전 로직에서는 토큰이 유효하지 않다면 무조건 필터링하는 방식으로 필터의 로직이 동작했다.

Filter와 Aspect의 역할을 아래와 같이 재정리했다.

- Filter: DB와 통신은 하지 않고, 헤더에 토큰이 담겨있다면 무조건 파싱하되 요청을 필터링하지는 않는다.
- Aspect: 필요에 따라 DB와 통신하고 사용자를 검증하며, 역할 기반의 권한 검증을 수행한다.

자세한 내용은 ISSUE#146 를 참고하면 좋을 것 같습니다.

## :sparkles: PR Point <!-- what you want reviewers to focus on -->

N/A

## :gift: Notes

N/A
