### PR TITLE
[#151] 파일 다운로드 API 구현

### DIFF
--- a/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileController.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileController.java
@@ -2,12 +2,10 @@ package com.eventty.eventtynextgen.asset.file;
 
 import com.eventty.eventtynextgen.asset.file.annotation.AssetFileApiV1;
 import com.eventty.eventtynextgen.asset.file.request.AssetFileUploadMultipartFileRequestCommand;
-import com.eventty.eventtynextgen.asset.file.response.AssetDownloadStreamingFileResponseView;
+import com.eventty.eventtynextgen.asset.file.response.AssetDownloadFileResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetFindFileMetadataResponseView;
-import com.eventty.eventtynextgen.asset.file.response.AssetGetAssetFileResponseView;
-import com.eventty.eventtynextgen.asset.file.response.AssetGetAssetFilesResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetGetFileMetadataResponseView;
-import com.eventty.eventtynextgen.asset.file.response.AssetUploadAssetFile;
+import com.eventty.eventtynextgen.asset.file.response.AssetUploadAssetFileResponseView;
 import com.eventty.eventtynextgen.base.annotation.LoginRequired;
 import com.eventty.eventtynextgen.shared.context.SessionContextHolder;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,7 +19,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -35,13 +32,13 @@ public class AssetFileController {
     @Operation(summary = "파일 업로드 API", description = "Multipart-File 형식의 단일 파일 업로드를 처리합니다.")
     @LoginRequired(requireHost = true, requireAdmin = true)
     @PostMapping(value = "/multipart-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<AssetUploadAssetFile> uploadMultipartFile(
+    public ResponseEntity<AssetUploadAssetFileResponseView> uploadMultipartFile(
         @RequestPart(value = "file") MultipartFile file,
         @RequestPart(value = "requestCommand") @Valid AssetFileUploadMultipartFileRequestCommand requestCommand) {
 
         Long userId = SessionContextHolder.getContext().getUserId();
 
-        AssetUploadAssetFile assetUploadAssetFile = this.assetFileService.uploadMultipartFile(file, userId, requestCommand.fileName());
+        AssetUploadAssetFileResponseView assetUploadAssetFile = this.assetFileService.uploadMultipartFile(file, userId, requestCommand.fileName());
 
         return ResponseEntity.ok(assetUploadAssetFile);
     }
@@ -65,9 +62,9 @@ public class AssetFileController {
     @Deprecated
     @LoginRequired(requireHost = true, requireAdmin = true)
         @PostMapping(value = "/multipart-files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<AssetUploadAssetFile>> uploadMultipartFiles(@RequestPart("files") List<MultipartFile> files) {
+    public ResponseEntity<List<AssetUploadAssetFileResponseView>> uploadMultipartFiles(@RequestPart("files") List<MultipartFile> files) {
 
-        List<AssetUploadAssetFile> assetUploadAssetFiles = this.assetFileService.uploadMultipartFiles(files);
+        List<AssetUploadAssetFileResponseView> assetUploadAssetFiles = this.assetFileService.uploadMultipartFiles(files);
 
         return ResponseEntity.ok(assetUploadAssetFiles);
     }
@@ -87,9 +84,9 @@ public class AssetFileController {
     @Deprecated
     @LoginRequired(requireHost = true, requireAdmin = true)
     @PostMapping("/stream-file")
-    public ResponseEntity<AssetUploadAssetFile> uploadStreamFile(HttpServletRequest request) {
+    public ResponseEntity<AssetUploadAssetFileResponseView> uploadStreamFile(HttpServletRequest request) {
 
-        AssetUploadAssetFile assetUploadAssetFile = this.assetFileService.uploadStreaming(request);
+        AssetUploadAssetFileResponseView assetUploadAssetFile = this.assetFileService.uploadStreaming(request);
 
         return ResponseEntity.ok(assetUploadAssetFile);
     }
@@ -110,5 +107,15 @@ public class AssetFileController {
         Long userId = SessionContextHolder.getContext().getUserId();
 
         return ResponseEntity.ok(this.assetFileService.getFileMetadata(userId, fileMetadataId));
+    }
+
+    @Operation(summary = "파일 다운로드 API", description = "업로드된 파일을 다운로드합니다.")
+    @LoginRequired(requireHost = true, requireAdmin = true)
+    @GetMapping("/download/{fileMetadataId}")
+    public ResponseEntity<AssetDownloadFileResponseView> downloadFile(@PathVariable("fileMetadataId") Long fileMetadataId) {
+        Long userId = SessionContextHolder.getContext().getUserId();
+
+//        this.assetFileService.
+        return null;
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileController.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileController.java
@@ -14,11 +14,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -111,11 +113,13 @@ public class AssetFileController {
 
     @Operation(summary = "파일 다운로드 API", description = "업로드된 파일을 다운로드합니다.")
     @LoginRequired(requireHost = true, requireAdmin = true)
-    @GetMapping("/download/{fileMetadataId}")
-    public ResponseEntity<AssetDownloadFileResponseView> downloadFile(@PathVariable("fileMetadataId") Long fileMetadataId) {
+    @GetMapping("/download")
+    public ResponseEntity<AssetDownloadFileResponseView> downloadFile(@RequestParam("fileMetadataId") Long fileMetadataId) {
         Long userId = SessionContextHolder.getContext().getUserId();
 
-//        this.assetFileService.
-        return null;
+        AssetDownloadFileResponseView assetDownloadFileResponseView = this.assetFileService.downloadFile(userId, fileMetadataId);
+        return ResponseEntity.ok()
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + assetDownloadFileResponseView.fileName() + "\"")
+            .body(assetDownloadFileResponseView);
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileService.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileService.java
@@ -1,9 +1,9 @@
 package com.eventty.eventtynextgen.asset.file;
 
+import com.eventty.eventtynextgen.asset.file.response.AssetDownloadFileResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetFindFileMetadataResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetGetFileMetadataResponseView;
-import com.eventty.eventtynextgen.asset.file.response.AssetUploadAssetFile;
-import jakarta.servlet.ServletInputStream;
+import com.eventty.eventtynextgen.asset.file.response.AssetUploadAssetFileResponseView;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
@@ -11,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface AssetFileService {
 
 
-    AssetUploadAssetFile uploadMultipartFile(MultipartFile file, Long userId, String fileName);
+    AssetUploadAssetFileResponseView uploadMultipartFile(MultipartFile file, Long userId, String fileName);
 
     /**
      * 복합 파일 업로드 처리 메서드입니다.
@@ -20,7 +20,7 @@ public interface AssetFileService {
      *             단일 파일 업로드를 파일 수만큼 병렬 호출하는 방식을 권장합니다. 대신 {@link #uploadMultipartFile(MultipartFile, Long, String) 사용을 권장합니다.
      */
     @Deprecated
-    List<AssetUploadAssetFile> uploadMultipartFiles(List<MultipartFile> files);
+    List<AssetUploadAssetFileResponseView> uploadMultipartFiles(List<MultipartFile> files);
 
     /**
      * ServletInputStream을 통해 원시 바이트 스트림을 업로드합니다.
@@ -40,9 +40,11 @@ public interface AssetFileService {
      * @deprecated 제약 사항으로 인해 사용이 권장되지 않습니다. 대신 {@link #uploadMultipartFile(MultipartFile, Long, String)}을 사용하세요.
      */
     @Deprecated
-    AssetUploadAssetFile uploadStreaming(HttpServletRequest request);
+    AssetUploadAssetFileResponseView uploadStreaming(HttpServletRequest request);
 
     AssetGetFileMetadataResponseView getFileMetadata(Long userId, Long fileMetadataId);
 
     AssetFindFileMetadataResponseView findFileMetadata(Long userId);
+
+    AssetDownloadFileResponseView downloadFile(Long userId, Long fileMetadataId);
 }

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImpl.java
@@ -182,6 +182,6 @@ public class AssetFileServiceImpl implements AssetFileService {
 
         String downloadLink = objectStorageClient.findFileDownloadLink(fileMetadata.getOriginFileName(), StorageContext.FILE);
 
-        return new AssetDownloadFileResponseView(fileMetadata.getId(), downloadLink);
+        return new AssetDownloadFileResponseView(fileMetadata.getId(), fileMetadata.getFileName(), fileMetadata.getContentType(), downloadLink);
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImpl.java
@@ -9,9 +9,10 @@ import com.eventty.eventtynextgen.asset.core.ObjectStorageClient.UploadFileResul
 import com.eventty.eventtynextgen.asset.file.component.FileMetadataValidator;
 import com.eventty.eventtynextgen.asset.file.component.FileMetadataValidator.VerifyResult;
 import com.eventty.eventtynextgen.asset.file.entity.FileMetadata;
+import com.eventty.eventtynextgen.asset.file.response.AssetDownloadFileResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetFindFileMetadataResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetGetFileMetadataResponseView;
-import com.eventty.eventtynextgen.asset.file.response.AssetUploadAssetFile;
+import com.eventty.eventtynextgen.asset.file.response.AssetUploadAssetFileResponseView;
 import com.eventty.eventtynextgen.asset.file.service.FileMetadataService;
 import com.eventty.eventtynextgen.base.exception.CustomException;
 import com.eventty.eventtynextgen.base.exception.enums.AssetErrorType;
@@ -20,6 +21,7 @@ import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +44,7 @@ public class AssetFileServiceImpl implements AssetFileService {
     private final ThreadPoolTaskExecutor gcsIoExecutor;
 
     @Override
-    public AssetUploadAssetFile uploadMultipartFile(MultipartFile file, Long userId, String fileName) {
+    public AssetUploadAssetFileResponseView uploadMultipartFile(MultipartFile file, Long userId, String fileName) {
 
         VerifyResult verifyResult = this.fileMetadataValidator.validateMultipartFile(file);
         handleVerifyResult(verifyResult);
@@ -54,7 +56,7 @@ public class AssetFileServiceImpl implements AssetFileService {
 
         FileMetadata fileMetadataFromDb = fileMetadataService.save(userId, uploadFileMetaData.fileName(), uploadFileMetaData.contentType(), uploadFileMetaData.fileUrl());
 
-        return new AssetUploadAssetFile(fileMetadataFromDb.getId(), fileMetadataFromDb.getFileName(), fileMetadataFromDb.getContentType(), fileMetadataFromDb.getFileUrl());
+        return new AssetUploadAssetFileResponseView(fileMetadataFromDb.getId(), fileMetadataFromDb.getFileName(), fileMetadataFromDb.getContentType(), fileMetadataFromDb.getFileUrl());
     }
 
     private String createFileFullName(Long userId, String fileName) {
@@ -63,7 +65,7 @@ public class AssetFileServiceImpl implements AssetFileService {
 
     @Deprecated
     @Override
-    public List<AssetUploadAssetFile> uploadMultipartFiles(List<MultipartFile> files) {
+    public List<AssetUploadAssetFileResponseView> uploadMultipartFiles(List<MultipartFile> files) {
         files.stream().map(this.fileMetadataValidator::validateMultipartFile).forEach(this::handleVerifyResult);
 
         List<CompletableFuture<UploadFileResult>> futures = files.stream()
@@ -99,13 +101,13 @@ public class AssetFileServiceImpl implements AssetFileService {
         }
 
         return results.stream()
-            .map(result -> new AssetUploadAssetFile(null, result.fileName(), result.contentType(), null))
+            .map(result -> new AssetUploadAssetFileResponseView(null, result.fileName(), result.contentType(), null))
             .toList();
     }
 
     @Deprecated
     @Override
-    public AssetUploadAssetFile uploadStreaming(HttpServletRequest request) {
+    public AssetUploadAssetFileResponseView uploadStreaming(HttpServletRequest request) {
         String contentType = request.getContentType();
         ServletInputStream inputStream;
         try {
@@ -124,7 +126,7 @@ public class AssetFileServiceImpl implements AssetFileService {
             throw CustomException.of(HttpStatus.INTERNAL_SERVER_ERROR, FILE_UPLOAD_FAILED, "File upload interrupted: " + e.getMessage());
         }
 
-        return new AssetUploadAssetFile(null, null, null, null);
+        return new AssetUploadAssetFileResponseView(null, null, null, null);
     }
 
     private void handleVerifyResult(VerifyResult verifyResult) {
@@ -163,5 +165,23 @@ public class AssetFileServiceImpl implements AssetFileService {
         ).toList();
 
         return new AssetFindFileMetadataResponseView(userId, fileMetaDatas);
+    }
+
+    @Override
+    public AssetDownloadFileResponseView downloadFile(Long userId, Long fileMetadataId) {
+
+        FileMetadata fileMetadata = fileMetadataService.findById(fileMetadataId);
+
+        if (!Objects.equals(userId, fileMetadata.getUserId())) {
+            throw CustomException.of(HttpStatus.FORBIDDEN, AssetErrorType.UNAUTHORIZED_FILE_ACCESS);
+        }
+
+        if (fileMetadata.isDeleted()) {
+            throw CustomException.of(HttpStatus.FORBIDDEN, AssetErrorType.NOT_ALLOW_ACCESS_DELETED_FILE);
+        }
+
+        String downloadLink = objectStorageClient.findFileDownloadLink(fileMetadata.getOriginFileName(), StorageContext.FILE);
+
+        return new AssetDownloadFileResponseView(fileMetadata.getId(), downloadLink);
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/entity/FileMetadata.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/entity/FileMetadata.java
@@ -77,6 +77,10 @@ public class FileMetadata {
         }
     }
 
+    public String getOriginFileName() {
+        return this.fileName;
+    }
+
     public void updateDeleteStatus(FileMetadataStatus status) {
         if (status == FileMetadataStatus.ACTIVE) {
             this.isDeleted = false;

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/response/AssetDownloadFileResponseView.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/response/AssetDownloadFileResponseView.java
@@ -5,8 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record AssetDownloadFileResponseView (
     @Schema(name = "파일 메타데이터 id")
     Long fileMetadataId,
+    @Schema(name = "파일 이름")
+    String fileName,
+    @Schema(name = "파일 타입")
+    String contentType,
     @Schema(name = "파일 다운로드 링크")
     String downloadLink
 ) {
-
 }

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/response/AssetDownloadFileResponseView.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/response/AssetDownloadFileResponseView.java
@@ -1,0 +1,12 @@
+package com.eventty.eventtynextgen.asset.file.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AssetDownloadFileResponseView (
+    @Schema(name = "파일 메타데이터 id")
+    Long fileMetadataId,
+    @Schema(name = "파일 다운로드 링크")
+    String downloadLink
+) {
+
+}

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/response/AssetDownloadStreamingFileResponseView.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/response/AssetDownloadStreamingFileResponseView.java
@@ -1,5 +1,0 @@
-package com.eventty.eventtynextgen.asset.file.response;
-
-public record AssetDownloadStreamingFileResponseView (){
-
-}

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/response/AssetUploadAssetFileResponseView.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/response/AssetUploadAssetFileResponseView.java
@@ -2,7 +2,7 @@ package com.eventty.eventtynextgen.asset.file.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record AssetUploadAssetFile(
+public record AssetUploadAssetFileResponseView(
     @Schema(name = "파일 메타데이터 id")
     Long fileMetadataId,
     @Schema(name = "파일 이름")

--- a/src/test/java/com/eventty/eventtynextgen/asset/core/GcsObjectStorageClientTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/asset/core/GcsObjectStorageClientTest.java
@@ -3,25 +3,18 @@ package com.eventty.eventtynextgen.asset.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.eventty.eventtynextgen.asset.core.ObjectStorageClient.FindFileUrlResult;
+import com.eventty.eventtynextgen.asset.core.ObjectStorageClient.StorageContext;
 import com.eventty.eventtynextgen.asset.core.ObjectStorageClient.UploadFileMetaData;
-import com.eventty.eventtynextgen.asset.core.ObjectStorageClient.UploadFileResult;
-import com.eventty.eventtynextgen.asset.utils.MultipartConvertHelper;
 import com.eventty.eventtynextgen.base.exception.CustomException;
 import com.eventty.eventtynextgen.base.exception.enums.AssetErrorType;
-import com.eventty.eventtynextgen.asset.core.ObjectStorageClient.StorageContext;
-import com.eventty.eventtynextgen.asset.core.ObjectStorageClient.FindFileUrlResult;
 import com.eventty.eventtynextgen.config.TestcontainersConfiguration;
-import java.io.File;
-import java.io.FileInputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,9 +25,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
 
-@Tag("ExternalIntegration")
+//@Tag("ExternalIntegration")
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DisplayName("GcsObjectStorageClient 통합 테스트")
@@ -620,6 +612,7 @@ class GcsObjectStorageClientTest {
     @Nested
     @DisplayName("파일 유무 확인 테스트")
     class FileExistsTest {
+
         @Test
         @DisplayName("존재하는 파일인 경우 true를 반환한다")
         void 존재하는_파일인_경우_true를_반환한다() throws Exception {
@@ -672,6 +665,7 @@ class GcsObjectStorageClientTest {
     @Nested
     @DisplayName("단일 파일 URL 조회 테스트")
     class FindFileUrlTest {
+
         @Test
         @DisplayName("1개의 파일 Name을 인자로 받아 공개 File Url를 조회하여 반환한다")
         void 단일_파일_Name을__인자로_받아_공개_File_Url를_조회하여_반환한다() throws Exception {
@@ -738,6 +732,7 @@ class GcsObjectStorageClientTest {
     @Nested
     @DisplayName("여러 파일 URL 조회 테스트")
     class FindFileUrlsTest {
+
         @Test
         @DisplayName("여러 개의 파일 Name을 인자로 받아 공개 File Urls를 조회하여 반환한다")
         void 여러_개의_파일_Name을_인자로_받아_공개_File_Urls를_조회하여_반환한다() throws Exception {
@@ -766,7 +761,8 @@ class GcsObjectStorageClientTest {
             fileNames.forEach(fileName -> {
                 try {
                     gcsImageStorageService.deleteFile(fileName, StorageContext.EVENT_IMAGE);
-                } catch (Exception ignored) {}
+                } catch (Exception ignored) {
+                }
             });
         }
 
@@ -796,7 +792,8 @@ class GcsObjectStorageClientTest {
             fileNames.forEach(fileName -> {
                 try {
                     gcsImageStorageService.deleteFile(fileName, StorageContext.EVENT_IMAGE);
-                } catch (Exception ignored) {}
+                } catch (Exception ignored) {
+                }
             });
         }
 
@@ -826,7 +823,8 @@ class GcsObjectStorageClientTest {
             fileNames.forEach(fileName -> {
                 try {
                     gcsImageStorageService.deleteFile(fileName, StorageContext.EVENT_IMAGE);
-                } catch (Exception ignored) {}
+                } catch (Exception ignored) {
+                }
             });
         }
 
@@ -863,7 +861,8 @@ class GcsObjectStorageClientTest {
             fileNames.forEach(fileName -> {
                 try {
                     gcsImageStorageService.deleteFile(fileName, StorageContext.EVENT_IMAGE);
-                } catch (Exception ignored) {}
+                } catch (Exception ignored) {
+                }
             });
         }
 
@@ -886,6 +885,7 @@ class GcsObjectStorageClientTest {
     @Nested
     @DisplayName("파일 다운로드 링크 조회 테스트")
     class FindFileDownloadLinkTest {
+
         @Test
         @DisplayName("파일 이름을 인자로 받아 다운로드 링크를 조회하여 반환한다")
         void 파일_이름을_인자로_받아_다운로드_링크를_조회하여_반환한다() throws Exception {
@@ -952,6 +952,7 @@ class GcsObjectStorageClientTest {
     @Nested
     @DisplayName("파일 삭제 테스트")
     class DeleteFileTest {
+
         @Test
         @DisplayName("파일 이름을 인자로 받아 파일을 삭제한다")
         void 파일_이름을_인자로_받아_파일을_삭제한다() throws Exception {

--- a/src/test/java/com/eventty/eventtynextgen/asset/core/GcsObjectStorageClientTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/asset/core/GcsObjectStorageClientTest.java
@@ -26,7 +26,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
 
-//@Tag("ExternalIntegration")
+@Tag("ExternalIntegration")
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DisplayName("GcsObjectStorageClient 통합 테스트")

--- a/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileControllerTest.java
@@ -16,7 +16,7 @@ import com.eventty.eventtynextgen.asset.file.entity.FileMetadata;
 import com.eventty.eventtynextgen.asset.file.fixture.FileMetadataFixture;
 import com.eventty.eventtynextgen.asset.file.repository.FileMetadataRepository;
 import com.eventty.eventtynextgen.asset.file.request.AssetFileUploadMultipartFileRequestCommand;
-import com.eventty.eventtynextgen.asset.file.response.AssetUploadAssetFile;
+import com.eventty.eventtynextgen.asset.file.response.AssetUploadAssetFileResponseView;
 import com.eventty.eventtynextgen.asset.utils.MultipartConvertHelper;
 import com.eventty.eventtynextgen.asset.utils.MultipartConvertHelper.MultipartFileInfo;
 import com.eventty.eventtynextgen.base.exception.CustomException;
@@ -128,7 +128,7 @@ class AssetFileControllerTest {
                 .andExpect(jsonPath("$.contentType").value("application/zip"));
 
             String contentAsString = resultActions.andReturn().getResponse().getContentAsString();
-            AssetUploadAssetFile assetUploadAssetFile = objectMapper.readValue(contentAsString, AssetUploadAssetFile.class);
+            AssetUploadAssetFileResponseView assetUploadAssetFile = objectMapper.readValue(contentAsString, AssetUploadAssetFileResponseView.class);
 
             objectStorageClient.deleteFile(user.getId() + "/" + assetUploadAssetFile.fileName(), StorageContext.FILE);
         }
@@ -165,7 +165,7 @@ class AssetFileControllerTest {
                 .andExpect(jsonPath("$.contentType").value("application/yaml"));
 
             String contentAsString = resultActions.andReturn().getResponse().getContentAsString();
-            AssetUploadAssetFile assetUploadAssetFile = objectMapper.readValue(contentAsString, AssetUploadAssetFile.class);
+            AssetUploadAssetFileResponseView assetUploadAssetFile = objectMapper.readValue(contentAsString, AssetUploadAssetFileResponseView.class);
 
             objectStorageClient.deleteFile(user.getId() + "/" + assetUploadAssetFile.fileName(), StorageContext.FILE);
         }
@@ -366,7 +366,7 @@ class AssetFileControllerTest {
                 .andExpect(jsonPath("$[*].contentType").isNotEmpty());
 
             String contentAsString = resultActions.andReturn().getResponse().getContentAsString();
-            List<AssetUploadAssetFile> assetUploadAssetFiles = objectMapper.readValue(contentAsString, new TypeReference<>() {
+            List<AssetUploadAssetFileResponseView> assetUploadAssetFiles = objectMapper.readValue(contentAsString, new TypeReference<>() {
             });
             assetUploadAssetFiles.forEach(assetFile -> objectStorageClient.deleteFile(assetFile.fileName(), StorageContext.FILE));
         }
@@ -405,7 +405,7 @@ class AssetFileControllerTest {
                 .andExpect(jsonPath("$[*].contentType").isNotEmpty());
 
             String contentAsString = resultActions.andReturn().getResponse().getContentAsString();
-            List<AssetUploadAssetFile> assetUploadAssetFiles = objectMapper.readValue(contentAsString, new TypeReference<>() {
+            List<AssetUploadAssetFileResponseView> assetUploadAssetFiles = objectMapper.readValue(contentAsString, new TypeReference<>() {
             });
             assetUploadAssetFiles.forEach(assetFile -> objectStorageClient.deleteFile(assetFile.fileName(), StorageContext.FILE));
         }
@@ -706,7 +706,7 @@ class AssetFileControllerTest {
 
             // 업로드된 파일 삭제
             String contentAsString = resultActions.andReturn().getResponse().getContentAsString();
-            AssetUploadAssetFile assetUploadAssetFile = objectMapper.readValue(contentAsString, AssetUploadAssetFile.class);
+            AssetUploadAssetFileResponseView assetUploadAssetFile = objectMapper.readValue(contentAsString, AssetUploadAssetFileResponseView.class);
             objectStorageClient.deleteFile(assetUploadAssetFile.fileName(), StorageContext.FILE);
         }
     }

--- a/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -22,6 +23,7 @@ import com.eventty.eventtynextgen.asset.utils.MultipartConvertHelper.MultipartFi
 import com.eventty.eventtynextgen.base.exception.CustomException;
 import com.eventty.eventtynextgen.base.exception.ErrorResponse;
 import com.eventty.eventtynextgen.base.exception.enums.AssetErrorType;
+import com.eventty.eventtynextgen.base.exception.enums.AuthErrorType;
 import com.eventty.eventtynextgen.base.exception.factory.ErrorResponseEntityFactory;
 import com.eventty.eventtynextgen.base.fixture.CertificationTokenFixture;
 import com.eventty.eventtynextgen.base.fixture.SessionTokenFixture;
@@ -901,6 +903,156 @@ class AssetFileControllerTest {
             ResultActions resultActions = mockMvc.perform(get(URL + "/" + fileMetadataFromDb.getId())
                 .header(AUTHORIZATION_HEADER, accessTokenHeaderValue)
                 .header(CERTIFICATION_TOKEN_COOKIE_NAME, certificationToken.getCertificationToken()));
+
+            // then
+            resultActions.andExpect(status().isForbidden())
+                .andExpect(content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
+        }
+    }
+
+    @Nested
+    @DisplayName("파일 다운로드 API")
+    class DownloadFile {
+
+        @BeforeEach
+        public void setup() {
+            fileMetadataRepository.deleteAllInBatch();
+        }
+
+        private static final String URL = BASE_URL + "/download";
+
+        @Tag("ExternalIntegration")
+        @Test
+        @DisplayName("파일 다운로드 API 호출 권한 검증에 성공하고 유효한 파일 메타데이터 ID를 파라미터로 전달하여 파일 다운로드 링크를 반환한다")
+        void 파일_다운로드_API_호출_권한_검증에_성공하고_유효한_파일_메타데이터_ID를_파라미터로_전달하여_파일_다운로드_링크를_반환한다() throws Exception {
+            // given
+            CertificationTokenInfo certificationToken = CertificationTokenFixture.createFullAuthorizedCertificationToken();
+            User user = UserFixture.createUserWithRoledHost();
+            User userFromDb = userRepository.save(user);
+            String accessTokenHeaderValue = SessionTokenFixture.createAccessTokenHeaderValue(userFromDb.getId());
+
+            String fileName = userFromDb.getId() + "/" + "file";
+            FileMetadata fileMetadata = FileMetadataFixture.createFileMetadata(userFromDb.getId(), fileName);
+            FileMetadata fileMetadataFromDb = fileMetadataRepository.save(fileMetadata);
+            MockMultipartFile file = new MockMultipartFile(fileName, fileName + ".json", fileMetadata.getContentType(), "content_type: json".getBytes());
+            objectStorageClient.uploadMultipartFile(file, fileName, StorageContext.FILE);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(get(URL)
+                .contentType(MULTIPART_FORM_DATA)
+                .header(AUTHORIZATION_HEADER, accessTokenHeaderValue)
+                .header(CERTIFICATION_TOKEN_COOKIE_NAME, certificationToken.getCertificationToken())
+                .param("fileMetadataId", fileMetadataFromDb.getId().toString()));
+
+            // then
+            resultActions.andExpect(status().isOk())
+                .andExpect(header().stringValues("Content-Disposition", "attachment; filename=\"" + fileMetadataFromDb.getFileName() + "\""))
+                .andExpect(jsonPath("$.fileMetadataId").value(fileMetadataFromDb.getId()))
+                .andExpect(jsonPath("$.fileName").value(fileMetadataFromDb.getFileName()))
+                .andExpect(jsonPath("$.contentType").value(fileMetadataFromDb.getContentType()))
+                .andExpect(jsonPath("$.downloadLink").isNotEmpty());
+
+            objectStorageClient.deleteFile(fileName, StorageContext.FILE);
+        }
+
+        @Test
+        @DisplayName("파일 다운로드 API 호출 권한 검증에 실패하면 예외 메시지를 전달한다")
+        void 파일_다운로드_API_호출_권한_검증에_실패하면_예외_메시지를_전달한다() throws Exception {
+            // given
+            CertificationTokenInfo certificationToken = CertificationTokenFixture.createFullAuthorizedCertificationToken();
+            User user = UserFixture.createUserWithRoledUser();
+            User userFromDb = userRepository.save(user);
+            String accessTokenHeaderValue = SessionTokenFixture.createAccessTokenHeaderValue(userFromDb.getId());
+
+            ResponseEntity<ErrorResponse> responseEntity = ErrorResponseEntityFactory.toResponseEntity(
+                CustomException.of(HttpStatus.FORBIDDEN, AuthErrorType.AUTH_USER_NOT_AUTHORIZED));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(get(URL)
+                .contentType(MULTIPART_FORM_DATA)
+                .header(AUTHORIZATION_HEADER, accessTokenHeaderValue)
+                .header(CERTIFICATION_TOKEN_COOKIE_NAME, certificationToken.getCertificationToken())
+                .param("fileMetadataId", "1"));
+
+            // then
+            resultActions.andExpect(status().isForbidden())
+                .andExpect(content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
+        }
+
+        @Test
+        @DisplayName("파일 다운로드 API 호출 권한 검증에 성공하나 존재하지 않는 파일 메타데이터 ID를 파라미터로 전달하면 예외 메시지를 전달한다")
+        void 파일_다운로드_API_호출_권한_검증에_성공하나_존재하지_않는_파일_메타데이터_ID를_파라미터로_전달하면_예외_메시지를_전달한다() throws Exception {
+            // given
+            CertificationTokenInfo certificationToken = CertificationTokenFixture.createFullAuthorizedCertificationToken();
+            User user = UserFixture.createUserWithRoledHost();
+            User userFromDb = userRepository.save(user);
+            String accessTokenHeaderValue = SessionTokenFixture.createAccessTokenHeaderValue(userFromDb.getId());
+
+            ResponseEntity<ErrorResponse> responseEntity = ErrorResponseEntityFactory.toResponseEntity(
+                CustomException.of(HttpStatus.NOT_FOUND, AssetErrorType.NOT_FOUND_FILE_METADATA));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(get(URL)
+                .contentType(MULTIPART_FORM_DATA)
+                .header(AUTHORIZATION_HEADER, accessTokenHeaderValue)
+                .header(CERTIFICATION_TOKEN_COOKIE_NAME, certificationToken.getCertificationToken())
+                .param("fileMetadataId", "1"));
+
+            // then
+            resultActions.andExpect(status().isNotFound())
+                .andExpect(content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
+        }
+
+        @Test
+        @DisplayName("파일 다운로드 API 호출 권한 검증에 성공하나 삭제된 파일 메타데이터를 조회한 경우 예외 메시지를 전달한다")
+        void 파일_다운로드_API_호출_권한_검증에_성공하나_삭제된_파일_메타데이터를_조회한_경우_예외_메시지를_전달한다() throws Exception {
+            // given
+            CertificationTokenInfo certificationToken = CertificationTokenFixture.createFullAuthorizedCertificationToken();
+            User user = UserFixture.createUserWithRoledHost();
+            User userFromDb = userRepository.save(user);
+            String accessTokenHeaderValue = SessionTokenFixture.createAccessTokenHeaderValue(userFromDb.getId());
+
+            String fileName = userFromDb.getId() + "/" + "file";
+            FileMetadata fileMetadata = FileMetadataFixture.createDeletedFileMetadata(userFromDb.getId(), fileName);
+            FileMetadata fileMetadataFromDb = fileMetadataRepository.save(fileMetadata);
+
+            ResponseEntity<ErrorResponse> responseEntity = ErrorResponseEntityFactory.toResponseEntity(
+                CustomException.of(HttpStatus.FORBIDDEN, AssetErrorType.NOT_ALLOW_ACCESS_DELETED_FILE));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(get(URL)
+                .contentType(MULTIPART_FORM_DATA)
+                .header(AUTHORIZATION_HEADER, accessTokenHeaderValue)
+                .header(CERTIFICATION_TOKEN_COOKIE_NAME, certificationToken.getCertificationToken())
+                .param("fileMetadataId", fileMetadataFromDb.getId().toString()));
+
+            // then
+            resultActions.andExpect(status().isForbidden())
+                .andExpect(content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
+        }
+
+        @Test
+        @DisplayName("파일 다운로드 API 호출 권한 검증에 성공하나 본인이 업로드하지 않은 파일 메타데이터를 조회한 경우 예외 메시지를 전달한다")
+        void 파일_다운로드_API_호출_권한_검증에_성공하나_본인이_업로드하지_않은_파일_메타데이터를_조회한_경우_예외_메시지를_전달한다() throws Exception {
+            // given
+            CertificationTokenInfo certificationToken = CertificationTokenFixture.createFullAuthorizedCertificationToken();
+            User user = UserFixture.createUserWithRoledHost();
+            User userFromDb = userRepository.save(user);
+            String accessTokenHeaderValue = SessionTokenFixture.createAccessTokenHeaderValue(userFromDb.getId());
+
+            String fileName = userFromDb.getId() + "/" + "file";
+            FileMetadata fileMetadata = FileMetadataFixture.createDeletedFileMetadata(userFromDb.getId() + 1, fileName);
+            FileMetadata fileMetadataFromDb = fileMetadataRepository.save(fileMetadata);
+
+            ResponseEntity<ErrorResponse> responseEntity = ErrorResponseEntityFactory.toResponseEntity(
+                CustomException.of(HttpStatus.FORBIDDEN, AssetErrorType.UNAUTHORIZED_FILE_ACCESS));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(get(URL)
+                .contentType(MULTIPART_FORM_DATA)
+                .header(AUTHORIZATION_HEADER, accessTokenHeaderValue)
+                .header(CERTIFICATION_TOKEN_COOKIE_NAME, certificationToken.getCertificationToken())
+                .param("fileMetadataId", fileMetadataFromDb.getId().toString()));
 
             // then
             resultActions.andExpect(status().isForbidden())

--- a/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImplTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImplTest.java
@@ -17,9 +17,10 @@ import com.eventty.eventtynextgen.asset.file.component.FileMetadataValidator;
 import com.eventty.eventtynextgen.asset.file.component.FileMetadataValidator.VerifyFileMetaResult;
 import com.eventty.eventtynextgen.asset.file.component.FileMetadataValidator.VerifyResult;
 import com.eventty.eventtynextgen.asset.file.entity.FileMetadata;
+import com.eventty.eventtynextgen.asset.file.response.AssetDownloadFileResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetFindFileMetadataResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetGetFileMetadataResponseView;
-import com.eventty.eventtynextgen.asset.file.response.AssetUploadAssetFile;
+import com.eventty.eventtynextgen.asset.file.response.AssetUploadAssetFileResponseView;
 import com.eventty.eventtynextgen.asset.file.service.FileMetadataService;
 import com.eventty.eventtynextgen.base.exception.CustomException;
 import com.eventty.eventtynextgen.base.exception.enums.AssetErrorType;
@@ -104,7 +105,7 @@ class AssetFileServiceImplTest {
             AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator, gcsIoExecutor);
 
             // when
-            AssetUploadAssetFile assetUploadAssetFile = assetFileService.uploadMultipartFile(file, userId, fileName);
+            AssetUploadAssetFileResponseView assetUploadAssetFile = assetFileService.uploadMultipartFile(file, userId, fileName);
 
             // then
             assertThat(assetUploadAssetFile.fileName()).isEqualTo(fileMetadata.getFileName());
@@ -237,7 +238,7 @@ class AssetFileServiceImplTest {
             AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator, gcsIoExecutor);
 
             // when
-            List<AssetUploadAssetFile> assetUploadAssetFiles = assetFileService.uploadMultipartFiles(List.of(file1, file2));
+            List<AssetUploadAssetFileResponseView> assetUploadAssetFiles = assetFileService.uploadMultipartFiles(List.of(file1, file2));
 
             // then
             assetUploadAssetFiles.forEach(assetUploadAssetFile -> {
@@ -413,7 +414,7 @@ class AssetFileServiceImplTest {
             AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator, gcsIoExecutor);
 
             // when
-            AssetUploadAssetFile assetUploadAssetFile = assetFileService.uploadStreaming(request);
+            AssetUploadAssetFileResponseView assetUploadAssetFile = assetFileService.uploadStreaming(request);
 
             // then
             assertThat(assetUploadAssetFile.fileName()).isEqualTo("streamed_test");
@@ -673,4 +674,100 @@ class AssetFileServiceImplTest {
         }
     }
 
+    @Nested
+    @DisplayName("파일 다운로드 테스트")
+    class DownloadFile {
+
+        @Test
+        @DisplayName("파일 메타데이터 ID를 통해 엔티티 조회에 성공하고 접근 권한 검증에 성공할 경우 파일 다운로드 링크를 반환한다")
+        void 파일_메타데이터_ID를_통해_엔티티_조회에_성공하고_접근_권한_검증에_성공할_경우_파일_다운로드_링크를_반환한다() {
+            // given
+            Long userId = 1L;
+            Long fileMetadataId = 2L;
+
+            FileMetadata fileMetadata = mock(FileMetadata.class);
+            when(fileMetadata.getId()).thenReturn(fileMetadataId);
+            when(fileMetadata.getUserId()).thenReturn(userId);
+            when(fileMetadata.isDeleted()).thenReturn(false);
+            when(fileMetadata.getOriginFileName()).thenReturn("1/테스트용이미지");
+
+            when(fileMetadataService.findById(fileMetadataId)).thenReturn(fileMetadata);
+
+            when(objectStorageClient.findFileDownloadLink(fileMetadata.getOriginFileName(), StorageContext.FILE)).thenReturn("http://example.com/test.jpg/download");
+
+            AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator, gcsIoExecutor);
+
+            // when
+            AssetDownloadFileResponseView result = assetFileService.downloadFile(userId, fileMetadataId);
+
+            // then
+            assertThat(result.fileMetadataId()).isEqualTo(2);
+            assertThat(result.downloadLink()).isEqualTo("http://example.com/test.jpg/download");
+        }
+
+        @Test
+        @DisplayName("파일 메타데이터 ID를 통해 엔티티 조회에 실패할 경우 예외를 그대로 던진다")
+        void 파일_메타데이터_ID를_통해_엔티티_조회에_실패할_경우_예외를_그대로_던진다() {
+            // given
+            Long userId = 1L;
+            Long fileMetadataId = 2L;
+
+            doThrow(CustomException.class).when(fileMetadataService).findById(fileMetadataId);
+
+            AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator, gcsIoExecutor);
+
+            // when & then
+            assertThatThrownBy(() -> assetFileService.downloadFile(userId, fileMetadataId))
+                .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("파일 메타데이터 ID를 통해 엔티티 조회에 성공하고 접근 권한 검증에 실패할 경우 예외를 발생시킨다")
+        void 파일_메타데이터_ID를_통해_엔티티_조회에_성공하고_접근_권한_검증에_실패할_경우_예외를_발생시킨다() {
+            // given
+            Long userId = 1L;
+            Long fileMetadataId = 2L;
+
+            FileMetadata fileMetadata = mock(FileMetadata.class);
+            when(fileMetadata.getUserId()).thenReturn(3L);
+
+            when(fileMetadataService.findById(fileMetadataId)).thenReturn(fileMetadata);
+
+            AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator, gcsIoExecutor);
+
+            // when & then
+            assertThatThrownBy(() -> assetFileService.downloadFile(userId, fileMetadataId))
+                .isInstanceOf(CustomException.class)
+                .satisfies((ex) -> {
+                    CustomException customException = (CustomException) ex;
+                    assertThat(customException.getErrorType()).isEqualTo(AssetErrorType.UNAUTHORIZED_FILE_ACCESS);
+                    assertThat(customException.getHttpStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+                });
+        }
+
+        @Test
+        @DisplayName("파일 메타데이터 ID를 통해 엔티티 조회에 성공하고 접근 권한 검증에 성공하지만 삭제된 파일인 경우 예외를 발생시킨다")
+        void 파일_메타데이터_ID를_통해_엔티티_조회에_성공하고_접근_권한_검증에_성공하지만_삭제된_파일인_경우_예외를_발생시킨다() {
+            // given
+            Long userId = 1L;
+            Long fileMetadataId = 2L;
+
+            FileMetadata fileMetadata = mock(FileMetadata.class);
+            when(fileMetadata.getUserId()).thenReturn(userId);
+            when(fileMetadata.isDeleted()).thenReturn(true);
+
+            when(fileMetadataService.findById(fileMetadataId)).thenReturn(fileMetadata);
+
+            AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator, gcsIoExecutor);
+
+            // when & then
+            assertThatThrownBy(() -> assetFileService.downloadFile(userId, fileMetadataId))
+                .isInstanceOf(CustomException.class)
+                .satisfies((ex) -> {
+                    CustomException customException = (CustomException) ex;
+                    assertThat(customException.getErrorType()).isEqualTo(AssetErrorType.NOT_ALLOW_ACCESS_DELETED_FILE);
+                    assertThat(customException.getHttpStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+                });
+        }
+    }
 }

--- a/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImplTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImplTest.java
@@ -688,6 +688,8 @@ class AssetFileServiceImplTest {
             FileMetadata fileMetadata = mock(FileMetadata.class);
             when(fileMetadata.getId()).thenReturn(fileMetadataId);
             when(fileMetadata.getUserId()).thenReturn(userId);
+            when(fileMetadata.getContentType()).thenReturn("application/multipart-data");
+            when(fileMetadata.getFileName()).thenReturn("테스트_파일_이름");
             when(fileMetadata.isDeleted()).thenReturn(false);
             when(fileMetadata.getOriginFileName()).thenReturn("1/테스트용이미지");
 


### PR DESCRIPTION
## :bell: Related issues <!-- Please write #[issue_number] -->

#151

## :pencil: Changes and Reasons <!-- Please list what you have changed and why. -->

**파일 다운로드 API 구현**

파일 다운로드 API는 GCS와 통신하여 파일을 다운로드 받을 수 있는 링크를 받아온 뒤 사용자에게 응답값으로 넘겨줍니다.

본인이 업로드한 파일만 API 호출을 수행할 수 있도록 강제하였습니다.

## :sparkles: PR Point <!-- what you want reviewers to focus on -->

N/A

## :gift: Notes

N/A
