### PR TITLE
[#155] 파일 삭제 API 구현

### DIFF
--- a/src/main/java/com/eventty/eventtynextgen/asset/core/GcsObjectStorageClient.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/core/GcsObjectStorageClient.java
@@ -136,7 +136,7 @@ public class GcsObjectStorageClient implements ObjectStorageClient {
             .toList();
 
         if (blobs.isEmpty()) {
-            throw CustomException.badRequest(AssetErrorType.NOT_FOUND_FILES);
+            throw CustomException.badRequest(AssetErrorType.NOT_FOUND_FILE);
         }
 
         Set<String> blobNameSet = blobs.stream()
@@ -165,7 +165,7 @@ public class GcsObjectStorageClient implements ObjectStorageClient {
         Blob blob = this.storage.get(BlobId.of(bucketName, fileName));
 
         if (blob == null) {
-            throw CustomException.badRequest(AssetErrorType.NOT_FOUND_FILES);
+            throw CustomException.badRequest(AssetErrorType.NOT_FOUND_FILE);
         }
 
         return blob.getMediaLink();
@@ -178,7 +178,7 @@ public class GcsObjectStorageClient implements ObjectStorageClient {
         }
 
         if (!existsFile(fileName, context)) {
-            throw CustomException.badRequest(AssetErrorType.NOT_FOUND_FILES);
+            throw CustomException.badRequest(AssetErrorType.NOT_FOUND_FILE);
         }
 
         String bucketName = getBucketInfo(context).getBucketName();

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileController.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileController.java
@@ -2,6 +2,7 @@ package com.eventty.eventtynextgen.asset.file;
 
 import com.eventty.eventtynextgen.asset.file.annotation.AssetFileApiV1;
 import com.eventty.eventtynextgen.asset.file.request.AssetFileUploadMultipartFileRequestCommand;
+import com.eventty.eventtynextgen.asset.file.response.AssetDeleteFileResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetDownloadFileResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetFindFileMetadataResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetGetFileMetadataResponseView;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -121,5 +123,16 @@ public class AssetFileController {
         return ResponseEntity.ok()
             .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + assetDownloadFileResponseView.fileName() + "\"")
             .body(assetDownloadFileResponseView);
+    }
+
+    @Operation(summary = "파일 삭제 API", description = "업로드된 파일을 삭제하고 파일의 메타데이터도 함께 삭제합니다.")
+    @LoginRequired(requireAdmin = true, requireHost = true)
+    @DeleteMapping
+    public ResponseEntity<AssetDeleteFileResponseView> deleteFile(@RequestParam("fileMetadataId") Long fileMetadataId) {
+        Long userId = SessionContextHolder.getContext().getUserId();
+
+        AssetDeleteFileResponseView assetDeleteFileResponseView = this.assetFileService.deleteFile(userId, fileMetadataId);
+
+        return ResponseEntity.ok(assetDeleteFileResponseView);
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileService.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileService.java
@@ -1,5 +1,6 @@
 package com.eventty.eventtynextgen.asset.file;
 
+import com.eventty.eventtynextgen.asset.file.response.AssetDeleteFileResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetDownloadFileResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetFindFileMetadataResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetGetFileMetadataResponseView;
@@ -47,4 +48,6 @@ public interface AssetFileService {
     AssetFindFileMetadataResponseView findFileMetadata(Long userId);
 
     AssetDownloadFileResponseView downloadFile(Long userId, Long fileMetadataId);
+
+    AssetDeleteFileResponseView deleteFile(Long userId, Long fileMetadataId);
 }

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImpl.java
@@ -9,6 +9,7 @@ import com.eventty.eventtynextgen.asset.core.ObjectStorageClient.UploadFileResul
 import com.eventty.eventtynextgen.asset.file.component.FileMetadataValidator;
 import com.eventty.eventtynextgen.asset.file.component.FileMetadataValidator.VerifyResult;
 import com.eventty.eventtynextgen.asset.file.entity.FileMetadata;
+import com.eventty.eventtynextgen.asset.file.response.AssetDeleteFileResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetDownloadFileResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetFindFileMetadataResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetGetFileMetadataResponseView;
@@ -17,6 +18,7 @@ import com.eventty.eventtynextgen.asset.file.service.FileMetadataService;
 import com.eventty.eventtynextgen.base.exception.CustomException;
 import com.eventty.eventtynextgen.base.exception.enums.AssetErrorType;
 import com.eventty.eventtynextgen.base.exception.enums.CommonErrorType;
+import com.eventty.eventtynextgen.shared.utils.LoggerUtils;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
@@ -183,5 +185,29 @@ public class AssetFileServiceImpl implements AssetFileService {
         String downloadLink = objectStorageClient.findFileDownloadLink(fileMetadata.getOriginFileName(), StorageContext.FILE);
 
         return new AssetDownloadFileResponseView(fileMetadata.getId(), fileMetadata.getFileName(), fileMetadata.getContentType(), downloadLink);
+    }
+
+    @Override
+    public AssetDeleteFileResponseView deleteFile(Long userId, Long fileMetadataId) {
+
+        FileMetadata fileMetadata = fileMetadataService.findById(fileMetadataId);
+
+        if (!Objects.equals(userId, fileMetadata.getUserId())) {
+            throw CustomException.of(HttpStatus.FORBIDDEN, AssetErrorType.UNAUTHORIZED_FILE_ACCESS);
+        }
+
+        if (fileMetadata.isDeleted()) {
+            throw CustomException.of(HttpStatus.FORBIDDEN, AssetErrorType.ALREADY_FILE_DELETED);
+        }
+
+        boolean deleted = this.objectStorageClient.deleteFile(fileMetadata.getOriginFileName(), StorageContext.FILE);
+
+        if (!deleted) {
+            throw CustomException.of(HttpStatus.INTERNAL_SERVER_ERROR, AssetErrorType.FAIL_GCS_FILE_DELETE, "userId: " + userId + ", fileMetadataId: " + fileMetadataId);
+        }
+
+        this.fileMetadataService.deleteById(fileMetadata.getId());
+
+        return new AssetDeleteFileResponseView(fileMetadata.getId());
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImpl.java
@@ -18,7 +18,6 @@ import com.eventty.eventtynextgen.asset.file.service.FileMetadataService;
 import com.eventty.eventtynextgen.base.exception.CustomException;
 import com.eventty.eventtynextgen.base.exception.enums.AssetErrorType;
 import com.eventty.eventtynextgen.base.exception.enums.CommonErrorType;
-import com.eventty.eventtynextgen.shared.utils.LoggerUtils;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/response/AssetDeleteFileResponseView.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/response/AssetDeleteFileResponseView.java
@@ -1,0 +1,10 @@
+package com.eventty.eventtynextgen.asset.file.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AssetDeleteFileResponseView(
+    @Schema(description = "파일 메타데이터 ID")
+    Long fileMetadataId
+) {
+
+}

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/service/FileMetadataService.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/service/FileMetadataService.java
@@ -10,4 +10,6 @@ public interface FileMetadataService {
     FileMetadata findById(Long fileMetadataId);
 
     List<FileMetadata> findAllByUserId(Long userId);
+
+    void deleteById(Long fileMetadataId);
 }

--- a/src/main/java/com/eventty/eventtynextgen/asset/file/service/FileMetadataServiceImpl.java
+++ b/src/main/java/com/eventty/eventtynextgen/asset/file/service/FileMetadataServiceImpl.java
@@ -3,6 +3,7 @@ package com.eventty.eventtynextgen.asset.file.service;
 import static com.eventty.eventtynextgen.base.exception.enums.AssetErrorType.*;
 
 import com.eventty.eventtynextgen.asset.file.entity.FileMetadata;
+import com.eventty.eventtynextgen.asset.file.entity.FileMetadata.FileMetadataStatus;
 import com.eventty.eventtynextgen.asset.file.repository.FileMetadataRepository;
 import com.eventty.eventtynextgen.base.exception.CustomException;
 import java.util.List;
@@ -23,17 +24,30 @@ public class FileMetadataServiceImpl implements FileMetadataService {
 
         FileMetadata fileMetadata = FileMetadata.of(userId, fileName, contentType, fileUrl);
 
-        return fileMetadataRepository.save(fileMetadata);
+        return this.fileMetadataRepository.save(fileMetadata);
     }
 
     @Override
     public FileMetadata findById(Long fileMetadataId) {
-        return fileMetadataRepository.findById(fileMetadataId)
+        return this.fileMetadataRepository.findById(fileMetadataId)
             .orElseThrow(() -> CustomException.of(HttpStatus.NOT_FOUND, NOT_FOUND_FILE_METADATA));
     }
 
     @Override
     public List<FileMetadata> findAllByUserId(Long userId) {
-        return fileMetadataRepository.findByUserId(userId);
+        return this.fileMetadataRepository.findByUserId(userId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteById(Long fileMetadataId) {
+        FileMetadata fileMetadata = this.fileMetadataRepository.findById(fileMetadataId)
+            .orElseThrow(() -> CustomException.badRequest(NOT_FOUND_FILE_METADATA, "fileMetadataId: " + fileMetadataId));
+
+        if (fileMetadata.isDeleted()) {
+            throw CustomException.badRequest(ALREADY_FILE_DELETED, "fileMetadataId: " + fileMetadataId);
+        }
+
+        fileMetadata.updateDeleteStatus(FileMetadataStatus.DELETED);
     }
 }

--- a/src/main/java/com/eventty/eventtynextgen/base/exception/enums/AssetErrorType.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/exception/enums/AssetErrorType.java
@@ -16,10 +16,12 @@ public enum AssetErrorType implements ErrorType {
     NOT_FOUND_FILE_METADATA("NOT_FOUND_FILE_METADATA", "파일 메타데이터를 찾을 수 없습니다."),
     UNAUTHORIZED_FILE_ACCESS("UNAUTHORIZED_FILE_ACCESS", "파일 메타데이터에 접근할 수 있는 권한이 없습니다."),
     NOT_ALLOW_ACCESS_DELETED_FILE("NOT_ALLOW_ACCESS_DELETED_FILE", "삭제된 파일에 접근을 허용하지 않습니다"),
+    ALREADY_FILE_DELETED("ALREADY_FILE_DELETED", "해당 파일은 이미 삭제되어 있습니다"),
 
     // Storage
     NOT_FOUND_BUCKET_NAME("NOT_FOUND_BUCKET_NAME", "Bucket Name을 찾을 수 없습니다. 파일 업로드 목적과 매칭되는 버킷이 존재하는지 다시 한번 확인해주세요."),
     NOT_FOUND_FILES("NOT_FOUND_FILES", "모든 파일을 찾을 수 없습니다."),
+    FAIL_GCS_FILE_DELETE("FAIL_FILE_DELETE", "GCS 서버에서 파일 삭제에 실패했습니다. 문제의 원인을 찾아서 해결한 후 다시 시도해주세요."),
 
     // Common
     ILLEGAL_ARGUMENT_FILE_CONTEXT("ILLEGAL_ARGUMENT_FILE_CONTEXT", "허용하지 않은 File Context 인자가 들어왔습니다.");

--- a/src/main/java/com/eventty/eventtynextgen/base/exception/enums/AssetErrorType.java
+++ b/src/main/java/com/eventty/eventtynextgen/base/exception/enums/AssetErrorType.java
@@ -20,7 +20,7 @@ public enum AssetErrorType implements ErrorType {
 
     // Storage
     NOT_FOUND_BUCKET_NAME("NOT_FOUND_BUCKET_NAME", "Bucket Name을 찾을 수 없습니다. 파일 업로드 목적과 매칭되는 버킷이 존재하는지 다시 한번 확인해주세요."),
-    NOT_FOUND_FILES("NOT_FOUND_FILES", "모든 파일을 찾을 수 없습니다."),
+    NOT_FOUND_FILE("NOT_FOUND_FILES", "파일을 찾을 수 없습니다."),
     FAIL_GCS_FILE_DELETE("FAIL_FILE_DELETE", "GCS 서버에서 파일 삭제에 실패했습니다. 문제의 원인을 찾아서 해결한 후 다시 시도해주세요."),
 
     // Common

--- a/src/test/java/com/eventty/eventtynextgen/asset/core/GcsObjectStorageClientTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/asset/core/GcsObjectStorageClientTest.java
@@ -723,7 +723,7 @@ class GcsObjectStorageClientTest {
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customException = (CustomException) ex;
-                    assertThat(customException.getErrorType()).isEqualTo(AssetErrorType.NOT_FOUND_FILES);
+                    assertThat(customException.getErrorType()).isEqualTo(AssetErrorType.NOT_FOUND_FILE);
                 });
         }
     }
@@ -877,7 +877,7 @@ class GcsObjectStorageClientTest {
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customException = (CustomException) ex;
-                    assertThat(customException.getErrorType()).isEqualTo(AssetErrorType.NOT_FOUND_FILES);
+                    assertThat(customException.getErrorType()).isEqualTo(AssetErrorType.NOT_FOUND_FILE);
                 });
         }
     }
@@ -922,7 +922,7 @@ class GcsObjectStorageClientTest {
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customException = (CustomException) ex;
-                    assertThat(customException.getErrorType()).isEqualTo(AssetErrorType.NOT_FOUND_FILES);
+                    assertThat(customException.getErrorType()).isEqualTo(AssetErrorType.NOT_FOUND_FILE);
                 });
         }
 
@@ -983,7 +983,7 @@ class GcsObjectStorageClientTest {
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customException = (CustomException) ex;
-                    assertThat(customException.getErrorType()).isEqualTo(AssetErrorType.NOT_FOUND_FILES);
+                    assertThat(customException.getErrorType()).isEqualTo(AssetErrorType.NOT_FOUND_FILE);
                 });
         }
 

--- a/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileControllerTest.java
@@ -3,6 +3,7 @@ package com.eventty.eventtynextgen.asset.file;
 import static com.eventty.eventtynextgen.base.constant.BaseConst.AUTHORIZATION_HEADER;
 import static com.eventty.eventtynextgen.certification.constant.CertificationConst.CERTIFICATION_TOKEN_COOKIE_NAME;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -1049,6 +1050,122 @@ class AssetFileControllerTest {
 
             // when
             ResultActions resultActions = mockMvc.perform(get(URL)
+                .contentType(MULTIPART_FORM_DATA)
+                .header(AUTHORIZATION_HEADER, accessTokenHeaderValue)
+                .header(CERTIFICATION_TOKEN_COOKIE_NAME, certificationToken.getCertificationToken())
+                .param("fileMetadataId", fileMetadataFromDb.getId().toString()));
+
+            // then
+            resultActions.andExpect(status().isForbidden())
+                .andExpect(content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
+        }
+    }
+
+    @Nested
+    @DisplayName("파일 삭제 API")
+    class DeleteFile {
+
+        @BeforeEach
+        public void setup() {
+            fileMetadataRepository.deleteAllInBatch();
+        }
+
+        private static final String URL = BASE_URL;
+
+        @Tag("ExternalIntegration")
+        @Test
+        @DisplayName("파일 삭제 API 호출 권한 검증에 성공하고 유효한 파일 메타데이터 ID를 파라미터로 전달하여 파일 삭제에 성공한다")
+        void 파일_삭제_API_호출_권한_검증에_성공하고_유효한_파일_메타데이터_ID를_파라미터로_전달하여_파일_삭제에_성공한다() throws Exception {
+            // given
+            CertificationTokenInfo certificationToken = CertificationTokenFixture.createFullAuthorizedCertificationToken();
+            User user = UserFixture.createUserWithRoledHost();
+            User userFromDb = userRepository.save(user);
+            String accessTokenHeaderValue = SessionTokenFixture.createAccessTokenHeaderValue(userFromDb.getId());
+
+            String fileName = userFromDb.getId() + "/" + "file";
+            FileMetadata fileMetadata = FileMetadataFixture.createFileMetadata(userFromDb.getId(), fileName);
+            FileMetadata fileMetadataFromDb = fileMetadataRepository.save(fileMetadata);
+            MockMultipartFile file = new MockMultipartFile(fileName, fileName + ".json", fileMetadata.getContentType(), "content_type: json".getBytes());
+            objectStorageClient.uploadMultipartFile(file, fileName, StorageContext.FILE);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(delete(URL)
+                .contentType(MULTIPART_FORM_DATA)
+                .header(AUTHORIZATION_HEADER, accessTokenHeaderValue)
+                .header(CERTIFICATION_TOKEN_COOKIE_NAME, certificationToken.getCertificationToken())
+                .param("fileMetadataId", fileMetadataFromDb.getId().toString()));
+
+            // then
+            resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.fileMetadataId").value(fileMetadataFromDb.getId()));
+        }
+
+        @Test
+        @DisplayName("파일 삭제 API 호출 권한 검증에 실패하면 예외 메시지를 전달한다")
+        void 파일_삭제_API_호출_권한_검증에_실패하면_예외_메시지를_전달한다() throws Exception {
+            // given
+            CertificationTokenInfo certificationToken = CertificationTokenFixture.createFullAuthorizedCertificationToken();
+            User user = UserFixture.createUserWithRoledUser();
+            User userFromDb = userRepository.save(user);
+            String accessTokenHeaderValue = SessionTokenFixture.createAccessTokenHeaderValue(userFromDb.getId());
+
+            ResponseEntity<ErrorResponse> responseEntity = ErrorResponseEntityFactory.toResponseEntity(
+                CustomException.of(HttpStatus.FORBIDDEN, AuthErrorType.AUTH_USER_NOT_AUTHORIZED));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(delete(URL)
+                .contentType(MULTIPART_FORM_DATA)
+                .header(AUTHORIZATION_HEADER, accessTokenHeaderValue)
+                .header(CERTIFICATION_TOKEN_COOKIE_NAME, certificationToken.getCertificationToken())
+                .param("fileMetadataId", "1"));
+
+            // then
+            resultActions.andExpect(status().isForbidden())
+                .andExpect(content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
+        }
+
+        @Test
+        @DisplayName("파일 삭제 API 호출 권한 검증에 성공하나 존재하지 않는 파일 메타데이터 ID를 파라미터로 전달하면 예외 메시지를 전달한다")
+        void 파일_삭제_API_호출_권한_검증에_성공하나_존재하지_않는_파일_메타데이터_ID를_파라미터로_전달하면_예외_메시지를_전달한다() throws Exception {
+            // given
+            CertificationTokenInfo certificationToken = CertificationTokenFixture.createFullAuthorizedCertificationToken();
+            User user = UserFixture.createUserWithRoledHost();
+            User userFromDb = userRepository.save(user);
+            String accessTokenHeaderValue = SessionTokenFixture.createAccessTokenHeaderValue(userFromDb.getId());
+
+            ResponseEntity<ErrorResponse> responseEntity = ErrorResponseEntityFactory.toResponseEntity(
+                CustomException.of(HttpStatus.NOT_FOUND, AssetErrorType.NOT_FOUND_FILE_METADATA));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(delete(URL)
+                .contentType(MULTIPART_FORM_DATA)
+                .header(AUTHORIZATION_HEADER, accessTokenHeaderValue)
+                .header(CERTIFICATION_TOKEN_COOKIE_NAME, certificationToken.getCertificationToken())
+                .param("fileMetadataId", "1"));
+
+            // then
+            resultActions.andExpect(status().isNotFound())
+                .andExpect(content().string(objectMapper.writeValueAsString(responseEntity.getBody())));
+        }
+
+        @Test
+        @DisplayName("파일 삭제 API 호출 권한 검증에 성공하나 삭제된 파일 메타데이터 ID를 파라미터로 전달하면 예외 메시지를 전달환다")
+        void 파일_삭제_API_호출_권한_검증에_성공하나_삭제된_파일_메타데이터_ID를_파라미터로_전달하면_예외_메시지를_전달환다() throws Exception {
+            // given
+            CertificationTokenInfo certificationToken = CertificationTokenFixture.createFullAuthorizedCertificationToken();
+            User user = UserFixture.createUserWithRoledHost();
+            User userFromDb = userRepository.save(user);
+            String accessTokenHeaderValue = SessionTokenFixture.createAccessTokenHeaderValue(userFromDb.getId());
+
+            String fileName = userFromDb.getId() + "/" + "file";
+            FileMetadata fileMetadata = FileMetadataFixture.createDeletedFileMetadata(userFromDb.getId() + 1, fileName);
+            FileMetadata fileMetadataFromDb = fileMetadataRepository.save(fileMetadata);
+
+            ResponseEntity<ErrorResponse> responseEntity = ErrorResponseEntityFactory.toResponseEntity(
+                CustomException.of(HttpStatus.FORBIDDEN, AssetErrorType.UNAUTHORIZED_FILE_ACCESS));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(delete(URL)
                 .contentType(MULTIPART_FORM_DATA)
                 .header(AUTHORIZATION_HEADER, accessTokenHeaderValue)
                 .header(CERTIFICATION_TOKEN_COOKIE_NAME, certificationToken.getCertificationToken())

--- a/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileControllerTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileControllerTest.java
@@ -1149,8 +1149,8 @@ class AssetFileControllerTest {
         }
 
         @Test
-        @DisplayName("파일 삭제 API 호출 권한 검증에 성공하나 삭제된 파일 메타데이터 ID를 파라미터로 전달하면 예외 메시지를 전달환다")
-        void 파일_삭제_API_호출_권한_검증에_성공하나_삭제된_파일_메타데이터_ID를_파라미터로_전달하면_예외_메시지를_전달환다() throws Exception {
+        @DisplayName("파일 삭제 API 호출 권한 검증에 성공하나 삭제된 파일 메타데이터 ID를 파라미터로 전달하면 예외 메시지를 전달한다")
+        void 파일_삭제_API_호출_권한_검증에_성공하나_삭제된_파일_메타데이터_ID를_파라미터로_전달하면_예외_메시지를_전달한다() throws Exception {
             // given
             CertificationTokenInfo certificationToken = CertificationTokenFixture.createFullAuthorizedCertificationToken();
             User user = UserFixture.createUserWithRoledHost();

--- a/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImplTest.java
+++ b/src/test/java/com/eventty/eventtynextgen/asset/file/AssetFileServiceImplTest.java
@@ -3,6 +3,8 @@ package com.eventty.eventtynextgen.asset.file;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -17,6 +19,7 @@ import com.eventty.eventtynextgen.asset.file.component.FileMetadataValidator;
 import com.eventty.eventtynextgen.asset.file.component.FileMetadataValidator.VerifyFileMetaResult;
 import com.eventty.eventtynextgen.asset.file.component.FileMetadataValidator.VerifyResult;
 import com.eventty.eventtynextgen.asset.file.entity.FileMetadata;
+import com.eventty.eventtynextgen.asset.file.response.AssetDeleteFileResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetDownloadFileResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetFindFileMetadataResponseView;
 import com.eventty.eventtynextgen.asset.file.response.AssetGetFileMetadataResponseView;
@@ -689,8 +692,8 @@ class AssetFileServiceImplTest {
             when(fileMetadata.getId()).thenReturn(fileMetadataId);
             when(fileMetadata.getUserId()).thenReturn(userId);
             when(fileMetadata.getContentType()).thenReturn("application/multipart-data");
-            when(fileMetadata.getFileName()).thenReturn("테스트_파일_이름");
             when(fileMetadata.isDeleted()).thenReturn(false);
+            when(fileMetadata.getFileName()).thenReturn("테스트용이미지");
             when(fileMetadata.getOriginFileName()).thenReturn("1/테스트용이미지");
 
             when(fileMetadataService.findById(fileMetadataId)).thenReturn(fileMetadata);
@@ -772,4 +775,173 @@ class AssetFileServiceImplTest {
                 });
         }
     }
+
+    @Nested
+    @DisplayName("파일 삭제하기 API")
+    class DeleteFile {
+
+        @Test
+        @DisplayName("파일 메타데이터 ID를 통해 유효한 엔티티 조회에 성공하고 접근 권한 검증에 성공할 경우 파일을 삭제 처리한다")
+        void 파일_메타데이터_ID를_통해_엔티티_조회에_성공하고_접근_권한_검증에_성공할_경우_파일을_삭제_처리한다() {
+            // given
+            Long userId = 1L;
+            Long fileMetadataId = 2L;
+
+            FileMetadata fileMetadata = mock(FileMetadata.class);
+            when(fileMetadata.getId()).thenReturn(fileMetadataId);
+            when(fileMetadata.getUserId()).thenReturn(userId);
+            when(fileMetadata.isDeleted()).thenReturn(false);
+
+            when(fileMetadataService.findById(fileMetadataId)).thenReturn(fileMetadata);
+            when(objectStorageClient.deleteFile(fileMetadata.getOriginFileName(), StorageContext.FILE)).thenReturn(true);
+            doNothing().when(fileMetadataService).deleteById(fileMetadataId);
+
+            AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator,
+                gcsIoExecutor);
+
+            // when
+            AssetDeleteFileResponseView result = assetFileService.deleteFile(userId, fileMetadataId);
+
+            // then
+            verify(objectStorageClient, times(1)).deleteFile(fileMetadata.getOriginFileName(), StorageContext.FILE);
+            verify(fileMetadataService, times(1)).deleteById(fileMetadataId);
+            assertThat(result.fileMetadataId()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("파일 메타데이터 ID를 통해 엔티티 조회에 실패할 경우 예외를 그대로 던진다")
+        void 파일_메타데이터_ID를_통해_엔티티_조회에_실패할_경우_예외를_그대로_던진다() {
+            // given
+            Long userId = 1L;
+            Long fileMetadataId = 2L;
+
+            doThrow(CustomException.class).when(fileMetadataService).findById(fileMetadataId);
+
+            AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator, gcsIoExecutor);
+
+            // when & then
+            assertThatThrownBy(() -> assetFileService.deleteFile(userId, fileMetadataId))
+                .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("파일 메타데이터 ID를 통해 유효한 엔티티 조회에 성공하지만 접근 권한 검증에 실패할 경우 예외를 발생시킨다")
+        void 파일_메타데이터_ID를_통해_유효한_엔티티_조회에_성공하지만_접근_권한_검증에_실패할_경우_예외를_발생시킨다() {
+            // given
+            Long userId = 1L;
+            Long fileMetadataId = 2L;
+
+            FileMetadata fileMetadata = mock(FileMetadata.class);
+            when(fileMetadata.getUserId()).thenReturn(3L);
+
+            when(fileMetadataService.findById(fileMetadataId)).thenReturn(fileMetadata);
+
+            AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator, gcsIoExecutor);
+
+            // when & then
+            assertThatThrownBy(() -> assetFileService.deleteFile(userId, fileMetadataId))
+                .isInstanceOf(CustomException.class)
+                .satisfies((ex) -> {
+                    CustomException customException = (CustomException) ex;
+                    assertThat(customException.getErrorType()).isEqualTo(AssetErrorType.UNAUTHORIZED_FILE_ACCESS);
+                    assertThat(customException.getHttpStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+                });
+        }
+
+        @Test
+        @DisplayName("파일 메타데이터 ID를 통해 삭제되어 있는 엔티티를 조회하고 접근 권한 검증에 통과할 경우 예외를 발생시킨다")
+        void 파일_메타데이터_ID를_통해_삭제되어_있는_엔티티를_조회하고_접근_권한_검증에_통과할_경우_예외를_발생시킨다() {
+            // given
+            Long userId = 1L;
+            Long fileMetadataId = 2L;
+
+            FileMetadata fileMetadata = mock(FileMetadata.class);
+            when(fileMetadata.getUserId()).thenReturn(userId);
+            when(fileMetadata.isDeleted()).thenReturn(true);
+
+            when(fileMetadataService.findById(fileMetadataId)).thenReturn(fileMetadata);
+
+            AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator, gcsIoExecutor);
+
+            // when & then
+            assertThatThrownBy(() -> assetFileService.deleteFile(userId, fileMetadataId))
+                .isInstanceOf(CustomException.class)
+                .satisfies((ex) -> {
+                    CustomException customException = (CustomException) ex;
+                    assertThat(customException.getErrorType()).isEqualTo(AssetErrorType.ALREADY_FILE_DELETED);
+                    assertThat(customException.getHttpStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+                });
+        }
+
+        @Test
+        @DisplayName("파일 메타데이터 ID를 통해 유효한 엔티티 조회에 성공하고 접근 권한 검증에 성공했지만 GCS 파일 삭제에 실패할 경우 예외를 그대로 던진다")
+        void 파일_메타데이터_ID를_통해_유효한_엔티티_조회에_성공하고_접근_권한_검증에_성공했지만_GCS_파일_삭제에_실패할_경우_예외를_그대로_던진다() {
+            // given
+            Long userId = 1L;
+            Long fileMetadataId = 2L;
+
+            FileMetadata fileMetadata = mock(FileMetadata.class);
+            when(fileMetadata.getUserId()).thenReturn(userId);
+            when(fileMetadata.isDeleted()).thenReturn(false);
+
+            when(fileMetadataService.findById(fileMetadataId)).thenReturn(fileMetadata);
+            when(objectStorageClient.deleteFile(fileMetadata.getOriginFileName(), StorageContext.FILE)).thenThrow(CustomException.class);
+
+            AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator,
+                gcsIoExecutor);
+            // when & then
+            assertThatThrownBy(() -> assetFileService.deleteFile(userId, fileMetadataId))
+                .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("파일 메타데이터 ID를 통해 유효한 엔티티 조회에 성공하고 접근 권한 검증에 성공했지만 GCS 파일 삭제 요청 결과값이 false일 경우 INTERNAL_SERVER_ERROR 예외를 발생시킨다")
+        void 파일_메타데이터_ID를_통해_유효한_엔티티_조회에_성공하고_접근_권한_검증에_성공했지만_GCS_파일_삭제_요청_결과값이_false일_경우_INTERNAL_SERVER_ERROR_예외를_발생시킨다() {
+            // given
+            Long userId = 1L;
+            Long fileMetadataId = 2L;
+
+            FileMetadata fileMetadata = mock(FileMetadata.class);
+            when(fileMetadata.getUserId()).thenReturn(userId);
+            when(fileMetadata.isDeleted()).thenReturn(false);
+
+            when(fileMetadataService.findById(fileMetadataId)).thenReturn(fileMetadata);
+            when(objectStorageClient.deleteFile(fileMetadata.getOriginFileName(), StorageContext.FILE)).thenReturn(false);
+
+            AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator, gcsIoExecutor);
+
+            // when & then
+            assertThatThrownBy(() -> assetFileService.deleteFile(userId, fileMetadataId))
+                .isInstanceOf(CustomException.class)
+                .satisfies((ex) -> {
+                    CustomException customException = (CustomException) ex;
+                    assertThat(customException.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+                    assertThat(customException.getErrorType()).isEqualTo(AssetErrorType.FAIL_GCS_FILE_DELETE);
+                });
+        }
+
+        @Test
+        @DisplayName("파일 메타데이터 ID를 통해 유효한 엔티티 조회에 성공하고 접근 권한 검증에 성공했으며 GCS 파일 삭제에 성공했지만 파일 메타데이터 삭제에 실패했다면 예외를 그대로 던진다")
+        void 파일_메타데이터_ID를_통해_유효한_엔티티_조회에_성공하고_접근_권한_검증에_성공했으며_GCS_파일_삭제에_성공했지만_파일_메타데이터_삭제에_실패했다면_예외를_그대로_던진다() {
+            // given
+            Long userId = 1L;
+            Long fileMetadataId = 2L;
+
+            FileMetadata fileMetadata = mock(FileMetadata.class);
+            when(fileMetadata.getId()).thenReturn(fileMetadataId);
+            when(fileMetadata.getUserId()).thenReturn(userId);
+            when(fileMetadata.isDeleted()).thenReturn(false);
+
+            when(fileMetadataService.findById(fileMetadataId)).thenReturn(fileMetadata);
+            when(objectStorageClient.deleteFile(fileMetadata.getOriginFileName(), StorageContext.FILE)).thenReturn(true);
+            doThrow(CustomException.class).when(fileMetadataService).deleteById(fileMetadataId);
+
+            AssetFileServiceImpl assetFileService = new AssetFileServiceImpl(fileMetadataService, objectStorageClient, fileMetaValidator,
+                gcsIoExecutor);
+
+            // when & then
+            assertThatThrownBy(() -> assetFileService.deleteFile(userId, fileMetadataId))
+                .isInstanceOf(CustomException.class);
+        }
+   }
 }


### PR DESCRIPTION
## :bell: Related issues <!-- Please write #[issue_number] -->

#155

## :pencil: Changes and Reasons <!-- Please list what you have changed and why. -->

**파일 삭제 API**

현재 구현한 파일 삭제하기 API의 비즈니스 로직은 크게 아래와 같이 진행된다.

1. 권한 검증
2. GCS와 통신하여 파일 삭제
3. DB와 통신하여 파일 메타데이터 삭제

현재 이 방식은 문제점이 존재하며, ISSUE[#155]에서 정리해 두었습니다. 또한 ISSUE[#156]에서 튜닝 작업을 진행할 것이니 참고해 주세요.

## :sparkles: PR Point <!-- what you want reviewers to focus on -->

N/A

## :gift: Notes

N/A
